### PR TITLE
Fix corner freq bug and misc cleanup

### DIFF
--- a/bin/gmsetup
+++ b/bin/gmsetup
@@ -18,7 +18,7 @@ def main(args):
     logging.info("Running gmsetup.")
 
     home_path = os.path.expanduser("~")
-    data_path = pkg_resources.resource_filename('gmprocess', 'data/')
+    data_path = pkg_resources.resource_filename('gmprocess', 'data')
 
     install_data_path_dict = {}
 

--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -73,7 +73,7 @@ windows:
         # none of the signal ends up in the noise window.
 
         # Valid options for "method" are "p_arrival" and "velocity"
-        method: velocity
+        method: p_arrival
         vsplit: 7.0
         # min_noise_duration: 5.0  # todo
 
@@ -102,7 +102,7 @@ corner_frequencies:
     # dynamically from the signal-to-noise-ratio.
 
     # Valid options for "method" are "constant" and "snr".
-    method: snr
+    method: constant
 
     constant:
         highpass: 0.08

--- a/gmprocess/logging.py
+++ b/gmprocess/logging.py
@@ -2,7 +2,7 @@ import logging
 import logging.config
 
 
-def setup_logger(args):
+def setup_logger(args=None):
     """Setup the logger options.
 
     Args:
@@ -15,12 +15,15 @@ def setup_logger(args):
            '%(module)s.%(funcName)s: %(message)s')
     datefmt = '%Y-%m-%d %H:%M:%S'
     # create a console handler, with verbosity setting chosen by user
-    if args.debug:
+    if args is not None:
+        if args.debug:
+            level = logging.DEBUG
+        elif args.quiet:
+            level = logging.ERROR
+        else:  # default interactive
+            level = logging.INFO
+    else:
         level = logging.DEBUG
-    elif args.quiet:
-        level = logging.ERROR
-    else:  # default interactive
-        level = logging.INFO
 
     logdict = {
         'version': 1,

--- a/gmprocess/plot.py
+++ b/gmprocess/plot.py
@@ -19,14 +19,16 @@ def get_time_from_percent(NIa, p, dt):
     calculate the duration time associated with the percent.
 
     Args:
-        NIa (array): Array of normalized Arias intensity values with respect to
-            time.
-        p (float): Percent (0 to 1) of Arias Intensity.
-        dt (float): Time in between each record in s.
+        NIa (array):
+            Array of normalized Arias intensity values with respect to time.
+        p (float):
+            Percent (0 to 1) of Arias Intensity.
+        dt (float):
+            Time in between each record in s.
 
     Returns:
         time (float): Duration time to reach specified percent of Arias
-            intensity.
+        intensity.
     """
 
     npts = len(NIa)
@@ -43,19 +45,29 @@ def plot_arias(stream, axes=None, axis_index=None,
     Create plots of arias intensity.
 
     Args:
-        stream (obspy.core.stream.Stream): Set of acceleration data with
-                units of gal (cm/s/s).
-        axes (ndarray): Array of subplots. Default is None.
-        axis_index (int): First index of axes array to plot the traces.
-                Default is None. Required if axes is not None.
-        figsize (tuple): Tuple of height and width. Default is None.
-        file (str): File where the image will be saved. Default is None.
-        minfontsize (int): Minimum font size. Default is 14.
-        show (bool): Plot the figure. Default is False.
-        show_maximum (bool): Show the maximum value.
-        title (str): Title for plot. Default is None.
-        xlabel (str): Label for x axis. Default is None.
-        ylabel (str): Label for y axis. Default is None.
+        stream (obspy.core.stream.Stream):
+            Set of acceleration data with units of gal (cm/s/s).
+        axes (ndarray):
+            Array of subplots. Default is None.
+        axis_index (int):
+            First index of axes array to plot the traces. Default is None.
+            Required if axes is not None.
+        figsize (tuple):
+            Tuple of height and width. Default is None.
+        file (str):
+            File where the image will be saved. Default is None.
+        minfontsize (int):
+            Minimum font size. Default is 14.
+        show (bool):
+            Plot the figure. Default is False.
+        show_maximum (bool):
+            Show the maximum value.
+        title (str):
+            Title for plot. Default is None.
+        xlabel (str):
+            Label for x axis. Default is None.
+        ylabel (str):
+            Label for y axis. Default is None.
 
     Returns:
         numpy.ndarray: Array of matplotlib.axes._subplots.AxesSubplot.
@@ -68,8 +80,8 @@ def plot_arias(stream, axes=None, axis_index=None,
 
     starttime = stream[0].stats.starttime
     if title is None:
-        title = 'Event on ' + str(starttime.month) + '/' + str(starttime.day) + '/' + \
-                str(starttime.year)
+        title = ('Event on ' + str(starttime.month) + '/' +
+                 str(starttime.day) + '/' + str(starttime.year))
     if xlabel is None:
         xlabel = 'Time (s)'
     if ylabel is None:
@@ -120,24 +132,33 @@ def plot_arias(stream, axes=None, axis_index=None,
 
 
 def plot_durations(stream, durations, axes=None, axis_index=None,
-                   figsize=None, file=None, minfontsize=14, show=False, title=None,
-                   xlabel=None, ylabel=None):
+                   figsize=None, file=None, minfontsize=14, show=False,
+                   title=None, xlabel=None, ylabel=None):
     """
     Create plots of durations.
 
     Args:
-        stream (obspy.core.stream.Stream): Set of acceleration data with
-                units of gal (cm/s/s).
-        durations (list): List of percentage minimum and maximums (tuple).
-        axes (ndarray): Array of subplots. Default is None.
-        axis_index (int): First index of axes array to plot the traces.
-                Default is None. Required if axes is not None.
-        figsize (tuple): Tuple of height and width. Default is None.
-        file (str): File where the image will be saved. Default is None.
-        show (bool): Plot the figure. Default is False.
-        title (str): Title for plot. Default is None.
-        xlabel (str): Label for x axis. Default is None.
-        ylabel (str): Label for y axis. Default is None.
+        stream (obspy.core.stream.Stream):
+            Set of acceleration data with units of gal (cm/s/s).
+        durations (list):
+            List of percentage minimum and maximums (tuple).
+        axes (ndarray):
+            Array of subplots. Default is None.
+        axis_index (int):
+            First index of axes array to plot the traces. Default is None.
+            Required if axes is not None.
+        figsize (tuple):
+            Tuple of height and width. Default is None.
+        file (str):
+            File where the image will be saved. Default is None.
+        show (bool):
+            Plot the figure. Default is False.
+        title (str):
+            Title for plot. Default is None.
+        xlabel (str):
+            Label for x axis. Default is None.
+        ylabel (str):
+            Label for y axis. Default is None.
 
     Returns:
         numpy.ndarray: Array of matplotlib.axes._subplots.AxesSubplot.
@@ -150,8 +171,8 @@ def plot_durations(stream, durations, axes=None, axis_index=None,
 
     starttime = stream[0].stats.starttime
     if title is None:
-        title = 'Event on ' + str(starttime.month) + '/' + str(starttime.day) + '/' + \
-                str(starttime.year)
+        title = ('Event on ' + str(starttime.month) + '/' +
+                 str(starttime.day) + '/' + str(starttime.year))
     if xlabel is None:
         xlabel = 'Time (s)'
     if ylabel is None:
@@ -211,27 +232,39 @@ def plot_durations(stream, durations, axes=None, axis_index=None,
     return axs
 
 
-def plot_moveout(streams, epilat, epilon, channel, cmap='viridis', figsize=None,
-                 file=None, minfontsize=14, normalize=False, scale=1, title=None,
-                 xlabel=None, ylabel=None):
+def plot_moveout(streams, epilat, epilon, channel, cmap='viridis',
+                 figsize=None, file=None, minfontsize=14, normalize=False,
+                 scale=1, title=None, xlabel=None, ylabel=None):
     """
     Create moveout plots.
 
     Args:
-        stream (obspy.core.stream.Stream): Set of acceleration data with
-                units of gal (cm/s/s).
-        epilat (float): Epicenter latitude.
-        epilon (float): Epicenter longitude.
-        channel (list): List of channels (str) of each stream to view.
-        cmap (str): Colormap name.
-        figsize (tuple): Tuple of height and width. Default is None.
-        file (str): File where the image will be saved. Default is None.
-        minfontsize (int): Minimum font size. Default is 14.
-        normalize (bool): Normalize the data. Default is faulse.
-        scale (int, float): Value to scale the trace by. Default is 1.
-        title (str): Title for plot. Default is None.
-        xlabel (str): Label for x axis. Default is None.
-        ylabel (str): Label for y axis. Default is None.
+        stream (obspy.core.stream.Stream):
+            Set of acceleration data with units of gal (cm/s/s).
+        epilat (float):
+            Epicenter latitude.
+        epilon (float):
+            Epicenter longitude.
+        channel (list):
+            List of channels (str) of each stream to view.
+        cmap (str):
+            Colormap name.
+        figsize (tuple):
+            Tuple of height and width. Default is None.
+        file (str):
+            File where the image will be saved. Default is None.
+        minfontsize (int):
+            Minimum font size. Default is 14.
+        normalize (bool):
+            Normalize the data. Default is faulse.
+        scale (int, float):
+            Value to scale the trace by. Default is 1.
+        title (str):
+            Title for plot. Default is None.
+        xlabel (str):
+            Label for x axis. Default is None.
+        ylabel (str):
+            Label for y axis. Default is None.
 
     Returns:
         tuple: (Figure, matplotlib.axes._subplots.AxesSubplot)
@@ -269,8 +302,8 @@ def plot_moveout(streams, epilat, epilon, channel, cmap='viridis', figsize=None,
     ax.invert_yaxis()
     ax.legend(bbox_to_anchor=(1, 1), fontsize=minfontsize)
     if title is None:
-        title = 'Event on ' + str(starttime.month) + '/' + str(starttime.day) + '/' + \
-                str(starttime.year)
+        title = ('Event on ' + str(starttime.month) + '/' +
+                 str(starttime.day) + '/' + str(starttime.year))
         if scale != 1:
             title += ' scaled by ' + str(scale)
     if xlabel is None:

--- a/gmprocess/windows.py
+++ b/gmprocess/windows.py
@@ -2,6 +2,7 @@
 """
 Helper functions for windowing singal and noise in a trace.
 """
+import os
 from importlib import import_module
 import pkg_resources
 import yaml
@@ -171,7 +172,7 @@ def signal_end(st, event_time, event_lon, event_lat, event_mag,
     # Load openquake stuff if method="model"
     if method == "model":
         mod_file = pkg_resources.resource_filename(
-            'gmprocess', 'data/modules.yml')
+            'gmprocess', os.path.join('data', 'modules.yml'))
         with open(mod_file, 'r') as f:
             mods = yaml.load(f)
 

--- a/tests/gmprocess/processing_test.py
+++ b/tests/gmprocess/processing_test.py
@@ -3,6 +3,7 @@
 # stdlib imports
 import os.path
 import glob
+import logging
 
 # third party imports
 from obspy.core.utcdatetime import UTCDateTime
@@ -34,6 +35,8 @@ def test_process_streams():
     streams = [read_data(f) for f in data_files]
     grouped_streams = group_channels(streams)
     test = process_streams(grouped_streams, origin)
+
+    logging.info('Testing trace: %s' % test[0][1])
 
     assert len(test) == 1
     assert len(test[0]) == 3

--- a/tests/gmprocess/processing_test.py
+++ b/tests/gmprocess/processing_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+# stdlib imports
+import os.path
+import glob
+
+# third party imports
+from obspy.core.utcdatetime import UTCDateTime
+import numpy as np
+
+# local imports
+from gmprocess.io.read import read_data
+from gmprocess.processing import process_streams
+from gmprocess.logging import setup_logger
+from gmprocess.stream import group_channels
+
+homedir = os.path.dirname(os.path.abspath(__file__))
+datadir = os.path.join(homedir, '..', 'data')
+
+setup_logger()
+
+
+def test_process_streams():
+    # Loma Prieta test station (nc216859)
+    origin = {
+        'eventid': 'test',
+        'time': UTCDateTime('2000-10-16T13:30:00'),
+        'magnitude': 7.3,
+        'lat': 35.278,
+        'lon': 133.345
+    }
+
+    data_files = glob.glob(os.path.join(datadir, 'kiknet', 'AICH04*'))
+    streams = [read_data(f) for f in data_files]
+    grouped_streams = group_channels(streams)
+    test = process_streams(grouped_streams, origin)
+
+    assert len(test) == 1
+    assert len(test[0]) == 3
+    np.testing.assert_allclose(
+        np.max(test[0][1].data),
+        4.8753232138021962
+    )
+
+
+if __name__ == '__main__':
+    test_process_streams()

--- a/tests/gmprocess/processing_test.py
+++ b/tests/gmprocess/processing_test.py
@@ -40,9 +40,16 @@ def test_process_streams():
 
     assert len(test) == 1
     assert len(test[0]) == 3
+
+    # Apparently the traces end up in a different order on the Travis linux
+    # container than on my local mac. So testing individual traces need to
+    # not care about trace order.
+
+    trace_maxes = np.sort([np.max(t.data) for t in test[0]])
+
     np.testing.assert_allclose(
-        np.max(test[0][1].data),
-        4.8753232138021962
+        trace_maxes,
+        np.array([1.30994939,  3.36651873,  4.87532321])
     )
 
 


### PR DESCRIPTION
Closes #65. Also:
- Checks so that it doesn't apply sensitivity correction if data units are not in counts
- Resolve some lookup of processing params inconsistencies
- Changes default filtering method to use constant corners; this is primarily so that tests don't have to change while we refine the corner frequency picking algorithm. 
- Changed the setup_logger method so that it can be called without command line args. Useful when debugging the code as a library. 
- Re-organized how the pretesting methods work. 