### PR TITLE
Resampling and corner frequency bug fix

### DIFF
--- a/gmprocess/corner_frequencies.py
+++ b/gmprocess/corner_frequencies.py
@@ -110,6 +110,11 @@ def snr(st, threshold=3.0, max_low_freq=0.1, min_high_freq=5.0,
                 else:
                     continue
 
+        # Swap the highs and lows if our SNR at the first frequency was
+        # above the threshold
+        if sig_spec_smooth[0] / noise_spec_smooth[0] >= threshold:
+            lows, highs = highs, lows
+
         # If we didn't find any corners
         if not lows:
             logging.info('Removing trace: %s (failed SNR check)' % tr)

--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -143,6 +143,19 @@ processing:
         #     constant, demean, linear, polynomial, simple, spline
         detrending_method: demean
 
+    - upsample:
+
+          # The new sampling rate, in Hz
+          new_sampling_rate: 200
+
+          # Currently only supporting Lanczos interpolation, which is generally
+          # the preferred method and offers the highest quality interpolation
+          method: lanczos
+
+          # Width of the Lanczos windows. Increasing "a" linearly increases
+          # run time, but also increases interpolation quality.
+          a: 50
+
     - cut:
         # No required options; the presence of this key just indicates when to
         # cut the time series using the record start and signal end that were

--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -143,19 +143,19 @@ processing:
         #     constant, demean, linear, polynomial, simple, spline
         detrending_method: demean
 
-    - resample:
-
-          # The new sampling rate, in Hz.
-          new_sampling_rate: 150
-
-          # Currently only supporting Lanczos interpolation, which is generally
-          # the preferred method and offers the highest quality interpolation.
-          method: lanczos
-
-          # Width of the Lanczos window, in number of samples. Increasing "a"
-          # linearly increases run time, but also increases interpolation.
-          # quality.
-          a: 50
+    # - resample:
+    #
+    #       # The new sampling rate, in Hz.
+    #       new_sampling_rate: 200
+    #
+    #       # Currently only supporting Lanczos interpolation, which is generally
+    #       # the preferred method and offers the highest quality interpolation.
+    #       method: lanczos
+    #
+    #       # Width of the Lanczos window, in number of samples. Increasing "a"
+    #       # linearly increases run time, but also increases interpolation.
+    #       # quality.
+    #       a: 50
 
     - cut:
         # No required options; the presence of this key just indicates when to

--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -143,17 +143,18 @@ processing:
         #     constant, demean, linear, polynomial, simple, spline
         detrending_method: demean
 
-    - upsample:
+    - resample:
 
-          # The new sampling rate, in Hz
-          new_sampling_rate: 200
+          # The new sampling rate, in Hz.
+          new_sampling_rate: 150
 
           # Currently only supporting Lanczos interpolation, which is generally
-          # the preferred method and offers the highest quality interpolation
+          # the preferred method and offers the highest quality interpolation.
           method: lanczos
 
-          # Width of the Lanczos windows. Increasing "a" linearly increases
-          # run time, but also increases interpolation quality.
+          # Width of the Lanczos window, in number of samples. Increasing "a"
+          # linearly increases run time, but also increases interpolation.
+          # quality.
           a: 50
 
     - cut:

--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -297,7 +297,7 @@ def resample(st, new_sampling_rate=None, method=None, a=None):
         sampling_rate (float):
             New sampling rate, in Hz.
         method (str):
-            Method for interpolation. Currently only supports Lanczos.
+            Method for interpolation. Currently only supports 'lanczos'.
         a (int):
             Width of the Lanczos window, in number of samples.
 

--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -288,40 +288,34 @@ def detrend(st, detrending_method=None):
     return st
 
 
-def upsample(st, new_sampling_rate=None, method=None, a=None):
-    """Upsample stream.
+def resample(st, new_sampling_rate=None, method=None, a=None):
+    """Resample stream.
 
     Args:
         st (obspy.core.stream.Stream):
             Stream of data.
-        sampling_rate (float): New sampling rate, in Hz.
-        method (str): Method for interpolation. Currenly only supports
-            Lanczos interpolation.
-        a (int): Width of the Lanczos window, in number of samples.
+        sampling_rate (float):
+            New sampling rate, in Hz.
+        method (str):
+            Method for interpolation. Currently only supports Lanczos.
+        a (int):
+            Width of the Lanczos window, in number of samples.
 
     Returns:
-        obspy.core.stream.Stream: Upsampled stream.
+        obspy.core.stream.Stream: Resampled stream.
     """
 
     if method != 'lanczos':
         raise ValueError('Only lanczos interpolation method is supported.')
 
     for tr in st:
-
-        # Check to make sure that the new sampling rate is greater than
-        # previous sampling rate (downsampling not allowed)
-        if tr.stats.sampling_rate > new_sampling_rate:
-            msg = 'Trace sampling rate is greater than new sampling rate.'
-            msg += 'Interpolation will not be applied.'
-            logging.warning(msg)
-        else:
-            tr.interpolate(sampling_rate=new_sampling_rate, method=method, a=a)
-            tr = _update_provenance(
-                tr, 'resample',
-                {
-                    'new_sampling_rate': new_sampling_rate
-                }
-            )
+        tr.interpolate(sampling_rate=new_sampling_rate, method=method, a=a)
+        tr = _update_provenance(
+            tr, 'resample',
+            {
+                'new_sampling_rate': new_sampling_rate
+            }
+        )
 
     return st
 

--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -288,6 +288,44 @@ def detrend(st, detrending_method=None):
     return st
 
 
+def upsample(st, new_sampling_rate=None, method=None, a=None):
+    """Upsample stream.
+
+    Args:
+        st (obspy.core.stream.Stream):
+            Stream of data.
+        sampling_rate (float): New sampling rate, in Hz.
+        method (str): Method for interpolation. Currenly only supports
+            Lanczos interpolation.
+        a (int): Width of the Lanczos window, in number of samples.
+
+    Returns:
+        obspy.core.stream.Stream: Upsampled stream.
+    """
+
+    if method != 'lanczos':
+        raise ValueError('Only lanczos interpolation method is supported.')
+
+    for tr in st:
+
+        # Check to make sure that the new sampling rate is greater than
+        # previous sampling rate (downsampling not allowed)
+        if tr.stats.sampling_rate > new_sampling_rate:
+            msg = 'Trace sampling rate is greater than new sampling rate.'
+            msg += 'Interpolation will not be applied.'
+            logging.warning(msg)
+        else:
+            tr.interpolate(sampling_rate=new_sampling_rate, method=method, a=a)
+            tr = _update_provenance(
+                tr, 'resample',
+                {
+                    'new_sampling_rate': new_sampling_rate
+                }
+            )
+
+    return st
+
+
 def cut(st, sec_before_split=None):
     """ Cut/trim the record.
 


### PR DESCRIPTION
- Adds a resampling method using Lanczos interpolation.
- Fixes bug in corner frequencies where the low corners and high corners were swapped if the SNR was greater than the threshold at the first frequency.

Closes #9 