### PR TITLE
cesmd event dirs

### DIFF
--- a/gmprocess/data/CESMD_NGA_ids.csv
+++ b/gmprocess/data/CESMD_NGA_ids.csv
@@ -1,0 +1,26 @@
+﻿CESMD directory,NGA eqid
+bigbear92,0126
+borregomountain_08apr1968,0028
+chalfantvalley86,0103
+chalfantvalley86a,0102
+coalinga_02may1983,0076
+coyotelake_06aug1979,0048
+hectormine99,0158
+imperialvalley79,0050
+imperialvalleyaftershock79,0051
+kerncounty_21jul1952,0012
+landers92,0125
+livermore80a,0053
+livermore80b,0054
+lomaprieta_17oct1989,0118
+lytlecreek70,0029
+morganhill84,0090
+northridge_17jan1994,0127
+palmsprings86,0101
+parkfield_27jun1966,0025
+petrolia_25apr1992,0123
+sanfernando_09feb1971,0030
+sanjuanbautista_12aug1998,0157
+sierramadre91,0145
+superstitionhills87,0116
+whittier87,0113


### PR DESCRIPTION
Add file for correspondance between cesmd event directory names and NGA event ids. This will help for any efforts to compare our processing of the CESMD data to what is in the NGA Flatfile. 