### PR TITLE
Remove codacy coverage stuff that we are not using

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ script:
     - py.test --cov=.
     - echo `sphinx-build --version`
 after_success:
-    - pip install codecov codacy-coverage
+    - pip install codecov
     - codecov
     - coverage xml
-    - python-codacy-coverage -r coverage.xml
     - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The command in the .travis.yml was creating an error. I was looking at this to try to figure out why our codecov report is not getting updated. 