### PR TITLE
Reworked radial-transverse IMC, various processing and metrics fixes

### DIFF
--- a/gmprocess/metrics/imt/arias.py
+++ b/gmprocess/metrics/imt/arias.py
@@ -64,6 +64,10 @@ def calculate_arias(stream, imcs, return_streams=False, origin=None):
                 arias = arias_func(arias_stream, origin=origin)
                 for channel in arias:
                     arias_dict[channel] = arias[channel]
+            elif imc.find('radial_transverse') >= 0:
+                arias = arias_func(arias_stream, origin=origin)
+                for channel in arias:
+                    arias_dict[channel] = arias[channel]
             else:
                 arias = arias_func(arias_stream, origin=origin)
                 arias_dict[imc.upper()] = arias

--- a/gmprocess/metrics/imt/fas.py
+++ b/gmprocess/metrics/imt/fas.py
@@ -56,7 +56,7 @@ def calculate_fas(stream, imcs, periods, smoothing, bandwidth):
     gm_trace = calculate_geometric_mean(spec_stream, return_combined=True)
     freqs = np.fft.rfftfreq(nfft, 1 / trace.stats.sampling_rate)
 
-    fas_frequencies = 1 / np.asarray(periods)
+    fas_frequencies = 1 / np.asarray(list(periods))
     smoothed_values = np.empty_like(fas_frequencies)
 
     if smoothing.lower() == 'konno_ohmachi':

--- a/gmprocess/metrics/imt/pga.py
+++ b/gmprocess/metrics/imt/pga.py
@@ -42,6 +42,9 @@ def calculate_pga(stream, imcs, origin=None):
             elif imc.find('channels') >= 0:
                 for channel in pga:
                     pga_dict[channel] = pga[channel]
+            elif imc.find('radial_transverse') >= 0:
+                for channel in pga:
+                    pga_dict[channel] = pga[channel]
             else:
                 pga_dict[imc.upper()] = pga
         else:

--- a/gmprocess/metrics/imt/pgv.py
+++ b/gmprocess/metrics/imt/pgv.py
@@ -41,6 +41,9 @@ def calculate_pgv(stream, imcs, origin=None):
             elif imc.find('channels') >= 0:
                 for channel in pgv:
                     pgv_dict[channel] = pgv[channel]
+            elif imc.find('radial_transverse') >= 0:
+                for channel in pgv:
+                    pgv_dict[channel] = pgv[channel]
             else:
                 pgv_dict[imc.upper()] = pgv
         else:

--- a/gmprocess/metrics/imt/sa.py
+++ b/gmprocess/metrics/imt/sa.py
@@ -51,6 +51,9 @@ def calculate_sa(stream, imcs, rotation_matrix=None, origin=None):
             elif imc.find('channels') >= 0:
                 for channel in sa:
                     sa_dict[channel] = sa[channel]
+            elif imc.find('radial_transverse') >= 0:
+                for channel in sa:
+                    sa_dict[channel] = sa[channel]
             else:
                 sa_dict[imc.upper()] = sa
         else:

--- a/gmprocess/metrics/station_summary.py
+++ b/gmprocess/metrics/station_summary.py
@@ -259,7 +259,8 @@ class StationSummary(object):
                         pgm_dict[tag] = {}
                         pgm_dict[tag]['GEOMETRIC_MEAN'] = fas[period]
                 elif oscillator.startswith('ARIAS'):
-                    arias = calculate_arias(stream, components, self.origin)
+                    arias = calculate_arias(stream, components,
+                                            origin=self.origin)
                     pgm_dict[oscillator] = arias
         components = []
         for imt in pgm_dict:

--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -130,6 +130,7 @@ def process_streams(streams, origin, config=None):
     # Loop over streams
     for stream in processed_streams:
         for processing_step_dict in processing_steps:
+            stream.check_stream()
             if stream.passed:
                 key_list = list(processing_step_dict.keys())
                 if len(key_list) != 1:
@@ -202,6 +203,7 @@ def remove_response(st, f1, f2, f3=None, f4=None, water_level=None,
             tr.remove_response(
                 inventory=inv, output=output, water_level=water_level,
                 pre_filt=(f1, f2, f3, f4))
+            tr.data *= 100  # Convert from m/s/s to cm/s/s
             tr.setProvenance(
                 'remove_response',
                 {
@@ -217,6 +219,7 @@ def remove_response(st, f1, f2, f3=None, f4=None, water_level=None,
         elif tr.stats.channel[1] == 'N':
             if isinstance(tr.data[0], int):
                 tr.remove_sensitivity(inventory=inv)
+                tr.data *= 100  # Convert from m/s/s to cm/s/s
                 tr.setProvenance(
                     'remove_response',
                     {
@@ -409,6 +412,12 @@ def lowpass_filter(st, filter_order=5, number_of_passes=2):
     for tr in st:
         freq_prov = tr.getParameter('corner_frequencies')
         freq = freq_prov['lowpass']
+
+        # Only perform low pass filter if corner is less than Nyquist frequency
+        # (half of the sampling rate)
+        if freq >= (0.5 * tr.stats.sampling_rate):
+            continue
+
         tr.filter(type="lowpass",
                   freq=freq,
                   corners=filter_order,

--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -18,6 +18,7 @@ from gmprocess import corner_frequencies
 # mistake.
 from gmprocess.pretesting import check_max_amplitude, check_sta_lta  # NOQA
 
+M_TO_CM = 100
 
 CONFIG = get_config()
 
@@ -203,7 +204,7 @@ def remove_response(st, f1, f2, f3=None, f4=None, water_level=None,
             tr.remove_response(
                 inventory=inv, output=output, water_level=water_level,
                 pre_filt=(f1, f2, f3, f4))
-            tr.data *= 100  # Convert from m/s/s to cm/s/s
+            tr.data *= M_TO_CM  # Convert from m/s/s to cm/s/s
             tr.setProvenance(
                 'remove_response',
                 {
@@ -219,7 +220,7 @@ def remove_response(st, f1, f2, f3=None, f4=None, water_level=None,
         elif tr.stats.channel[1] == 'N':
             if isinstance(tr.data[0], int):
                 tr.remove_sensitivity(inventory=inv)
-                tr.data *= 100  # Convert from m/s/s to cm/s/s
+                tr.data *= M_TO_CM  # Convert from m/s/s to cm/s/s
                 tr.setProvenance(
                     'remove_response',
                     {

--- a/tests/gmprocess/metrics/radial_transverse_test.py
+++ b/tests/gmprocess/metrics/radial_transverse_test.py
@@ -50,10 +50,10 @@ def test_radial_transverse():
         st2, ['radial_transverse'], ['pga'], origin)
 
     np.testing.assert_almost_equal(
-        pgms[0], sp.g * summary.pgms['PGA']['RADIAL_TRANSVERSE']['R'])
+        pgms[0], sp.g * summary.pgms['PGA']['R'])
 
     np.testing.assert_almost_equal(
-        pgms[1], sp.g * summary.pgms['PGA']['RADIAL_TRANSVERSE']['T'])
+        pgms[1], sp.g * summary.pgms['PGA']['T'])
 
     # Test with a station whose channels are not aligned to E-N
     SEW_st = read(os.path.join(datadir, 'resp_cor', 'GS.SEW.*.mseed'))
@@ -79,10 +79,10 @@ def test_radial_transverse():
         SEW_st, ['radial_transverse'], ['pga'], origin)
 
     np.testing.assert_almost_equal(
-        pgms[1], sp.g * summary.pgms['PGA']['RADIAL_TRANSVERSE']['R'])
+        pgms[1], sp.g * summary.pgms['PGA']['R'])
 
     np.testing.assert_almost_equal(
-        pgms[2], sp.g * summary.pgms['PGA']['RADIAL_TRANSVERSE']['T'])
+        pgms[2], sp.g * summary.pgms['PGA']['T'])
 
     # Test failure case without two horizontal channels
     copy1 = st.copy()


### PR DESCRIPTION
- Reworked radial-transverse IMC to be consistent with other IMCS in the dictionary that it returns. This required modifying IMT files as well.
- `stationTrace.getParameter()` can either return a dict or list, so this required modifying some processing steps to check for a list vs. dict.
- Fixed an issue related to enforcing the same filter frequencies for horizontal channels
- Fixed an issue calculating frequencies associated with FAS periods.
- `stationStream.check_stream()` is now called before each processing step.
- `remove_response()` now directly converts data from m/s/s to cm/s/s.
- Fixed an issue in low pass filter such that the low pass filter is only applied if the filter frequency is less than the Nyquist frequency.