### PR TITLE
Moved window check to its own step

### DIFF
--- a/gmprocess/corner_frequencies.py
+++ b/gmprocess/corner_frequencies.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from obspy.signal.util import next_pow_2
 
-from gmprocess.plot import plot_SNR
+from gmprocess.plot import summary_plot
 from gmprocess.config import get_config
 from gmprocess.smoothing.konno_ohmachi import konno_ohmachi_smooth
 
@@ -86,12 +86,10 @@ def snr(st, threshold=3.0, max_low_freq=0.1, min_high_freq=5.0,
                      type=TAPER_TYPE,
                      side=TAPER_SIDE)
 
-        # Find the number of points for the Fourier transform
-        if signal.stats.npts <= 0 or noise.stats.npts <= 0:
-            tr.fail('Invalid noise window or signal window')
-            continue
-
-        nfft = max(next_pow_2(signal.stats.npts), next_pow_2(noise.stats.npts))
+        # the np.max is there to avoid getting an error when
+        # next_pow_2 is handed zeros.
+        nfft = max(next_pow_2(np.max(signal.stats.npts), 2),
+                   next_pow_2(np.max(noise.stats.npts), 2))
 
         # Transform to frequency domain and smooth spectra using
         # konno-ohmachi smoothing
@@ -128,9 +126,9 @@ def snr(st, threshold=3.0, max_low_freq=0.1, min_high_freq=5.0,
         # If we didn't find any corners
         if not lows:
             tr.fail('SNR not greater than required threshold.')
-            plot_SNR(tr, sig_spec, sig_spec_smooth, noise_spec,
-                     noise_spec_smooth, sig_spec_freqs, freqs_signal,
-                     threshold, plot_dir)
+            summary_plot(tr, sig_spec, sig_spec_smooth, noise_spec,
+                         noise_spec_smooth, sig_spec_freqs, freqs_signal,
+                         threshold, plot_dir)
             continue
 
         # If we find an extra low, add another high for the maximum frequency
@@ -158,9 +156,9 @@ def snr(st, threshold=3.0, max_low_freq=0.1, min_high_freq=5.0,
             tr.fail('SNR not met within the required bandwidth.')
 
         if make_plots:
-            plot_SNR(tr, sig_spec, sig_spec_smooth, noise_spec,
-                     noise_spec_smooth, sig_spec_freqs, freqs_signal,
-                     threshold, plot_dir)
+            summary_plot(tr, sig_spec, sig_spec_smooth, noise_spec,
+                         noise_spec_smooth, sig_spec_freqs, freqs_signal,
+                         threshold, plot_dir)
 
     if same_horiz:
 

--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -46,6 +46,7 @@ read:
 #    |                    |          \/             |
 #
 #    record_start       split              signal_end
+
 windows:
 
     split:
@@ -57,7 +58,6 @@ windows:
         # Valid options for "method" are "p_arrival" and "velocity"
         method: p_arrival
         vsplit: 7.0
-        # min_noise_duration: 5.0  # todo
 
     signal_end:
         # The end of the signal can be set using a phase velocity.
@@ -75,6 +75,14 @@ windows:
         # Number of standard deviations; if epsilon is 1.0, then the signal
         # window duration is the mean Ds + 1 standard deviation.
         epsilon: 2.0
+
+    window_checks:
+        # Minimum noise duration; can be zero but this will allow for errors
+        # to occur if requesting signal-to-noise ratios.
+        min_noise_duration: 0.0
+
+        min_signal_duration: 5.0
+
 
 # -----------------------------------------------------------------------------
 # Corner frequency options

--- a/gmprocess/plot.py
+++ b/gmprocess/plot.py
@@ -322,8 +322,8 @@ def plot_moveout(streams, epilat, epilon, channel, cmap='viridis',
     return (fig, ax)
 
 
-def plot_SNR(tr, sig_spec, sig_spec_smooth, noise_spec, noise_spec_smooth,
-             freqs, freqs_smooth, threshold, save_dir):
+def summary_plot(tr, sig_spec, sig_spec_smooth, noise_spec, noise_spec_smooth,
+                 freqs, freqs_smooth, threshold, save_dir):
     """
     Create a plot showing signal-to-noise ratio information, the
     trace itself, and tables showing provenance and parameter information.


### PR DESCRIPTION
- Window duration check was only checking for zero length vectors and was not controllable by the conf file; this makes it configurable and a distinct step in the processing workflow. When it was failing it was causing some weirdness because it would have to then pass by a bunch of code. 
- Renamed "plot_SNR" to "summary_plot" since it shows so much more than just SNR and in fact I think we should make the plot even if we can't get the SNR due to a lack of noise window.