### PR TITLE
Processing

### DIFF
--- a/gmprocess/corner_frequencies.py
+++ b/gmprocess/corner_frequencies.py
@@ -3,8 +3,6 @@
 Methods for handling/picking corner frequencies.
 """
 
-from gmprocess.plot import summary_plot
-from gmprocess.config import get_config
 from gmprocess.snr import compute_snr
 
 # Options for tapering noise/signal windows
@@ -38,7 +36,7 @@ def constant(tr, highpass=0.08, lowpass=20.0):
     return tr
 
 
-def snr(tr, same_horiz=True):
+def snr(tr, same_horiz=True, bandwidth=20):
     """Use constant corner frequencies across all records.
 
     Args:
@@ -47,6 +45,8 @@ def snr(tr, same_horiz=True):
         same_horiz (bool):
             If True, horizontal traces in the stream must have the same
             corner frequencies.
+        bandwidth (float):
+            Konno-Omachi smoothing bandwidth parameter.
 
     Returns:
         stream: stream with selected corner frequencies appended to records.
@@ -54,7 +54,7 @@ def snr(tr, same_horiz=True):
 
     # Check for prior calculation of 'snr'
     if not tr.hasParameter('snr'):
-        tr = compute_snr(tr)
+        tr = compute_snr(tr, bandwidth)
 
     # If it doesn't exist then it must have failed because it didn't have
     # enough points in the noise or singal windows
@@ -89,9 +89,6 @@ def snr(tr, same_horiz=True):
         # If we didn't find any corners
         if not lows:
             tr.fail('SNR not greater than required threshold.')
-#            summary_plot(tr, sig_spec, sig_spec_smooth, noise_spec,
-#                         noise_spec_smooth, sig_spec_freqs, freqs_signal,
-#                         threshold, plot_dir)
             return tr
 
         # If we find an extra low, add another high for the maximum

--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -165,8 +165,9 @@ processing:
     #       # The new sampling rate, in Hz.
     #       new_sampling_rate: 200
     #
-    #       # Currently only supporting Lanczos interpolation, which is generally
-    #       # the preferred method and offers the highest quality interpolation.
+    #       # Currently only supporting Lanczos interpolation, which is
+    #       # generall the preferred method and offers the highest quality
+    #       # interpolation.
     #       method: lanczos
     #
     #       # Width of the Lanczos window, in number of samples. Increasing "a"
@@ -208,6 +209,16 @@ processing:
         # terms to be zero. The second derivative of the fit polynomial is then
         # removed from the acceleration time series.
         detrending_method: baseline_sixth_order
+
+    - fit_spectra:
+        # Fit a Brune spectra to the data by adjusting stress drop with an
+        # assumed kappa.
+        kappa: 0.035
+
+    - summary_plots:
+        # Make summary plots and put them in this directory:
+        directory: 'plotdir'
+
 
 # -----------------------------------------------------------------------------
 # This section is for calculating metrics

--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -85,32 +85,6 @@ windows:
 
 
 # -----------------------------------------------------------------------------
-# Corner frequency options
-corner_frequencies:
-
-    # Corner frequency selection can use constant values, or selected
-    # dynamically from the signal-to-noise-ratio.
-
-    # Valid options for "method" are "constant" and "snr".
-    method: constant
-
-    constant:
-        highpass: 0.08
-        lowpass: 20.0
-
-    snr:
-        # For dynamic filtering, we require a minimum SNR threshold between
-        # max_low_freq and min_high_freq after the spectra is smoothed with the
-        # Konno-Omachi method (with bandwidth parameter "b")
-        threshold: 3.0
-        max_low_freq: 0.2
-        min_high_freq: 5.0
-        bandwidth: 20.0
-        same_horiz: True
-        make_plots: False
-        plot_dir: directory
-
-# -----------------------------------------------------------------------------
 # This section is for processing steps that will affect the waveform and get
 # recorded as seismological provenance data.
 processing:
@@ -133,7 +107,7 @@ processing:
     - check_sta_lta:
         sta_length: 1.0
         lta_length: 20.0
-        threshold: 4.0
+        threshold: 3.0
 
     - remove_response:
         # Outuput units. Must be 'ACC', 'VEL', or 'DISP'.
@@ -168,6 +142,23 @@ processing:
         min_freq: 0.2
         max_freq: 5.0
         bandwidth: 20.0
+
+    - get_corner_frequencies:
+        # Corner frequency selection can use constant values, or selected
+        # dynamically from the signal-to-noise-ratio.
+        
+        # Valid options for "method" are "constant" and "snr".
+        method: constant
+
+        constant:
+            highpass: 0.08
+            lowpass: 20.0
+
+        snr:
+            # For dynamic filtering, we require a minimum SNR threshold between
+            # as configured in the snr_check step.
+            same_horiz: True
+
 
     # - resample:
     #

--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -135,8 +135,6 @@ processing:
         lta_length: 20.0
         threshold: 4.0
 
-
-
     - remove_response:
         # Outuput units. Must be 'ACC', 'VEL', or 'DISP'.
         output: 'ACC'
@@ -162,6 +160,15 @@ processing:
         #     constant, demean, linear, polynomial, simple, spline
         detrending_method: demean
 
+    - snr_check:
+        # Presense of this check says to do the signa-to-noise ratio check. Requires
+        # minimum SNR of `threshold` between `min_freq` and `max_freq` using
+        # Konno-Omachi smoothed spectra with `bandwidth` parameter.
+        threshold: 3.0
+        min_freq: 0.2
+        max_freq: 5.0
+        bandwidth: 20.0
+
     # - resample:
     #
     #       # The new sampling rate, in Hz.
@@ -181,7 +188,7 @@ processing:
         # cut the time series using the record start and signal end that were
         # configured in the windows section.
 
-        # Optionally, can specify how many sections to include prior to the
+        # Optionally, can specify how many seconds to include prior to the
         # split between the noise and signal windows. If set to "Null" then
         # the beginning of the record will be unchanged.
         sec_before_split: 2.0

--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -127,6 +127,16 @@ processing:
         min: 5
         max: 2e6
 
+
+    # STA/LTA is computed for record and the max value must exceed the threshold
+    # below. Units are sec for window lenghts.
+    - check_sta_lta:
+        sta_length: 1.0
+        lta_length: 20.0
+        threshold: 4.0
+
+
+
     - remove_response:
         # Outuput units. Must be 'ACC', 'VEL', or 'DISP'.
         output: 'ACC'
@@ -165,13 +175,6 @@ processing:
     #       # linearly increases run time, but also increases interpolation.
     #       # quality.
     #       a: 50
-
-    # STA/LTA is computed for record and the max value must exceed the threshold
-    # below. Units are sec for window lenghts.
-    - check_sta_lta:
-        sta_length: 1.0
-        lta_length: 20.0
-        threshold: 4.0
 
     - cut:
         # No required options; the presence of this key just indicates when to

--- a/gmprocess/fft.py
+++ b/gmprocess/fft.py
@@ -5,32 +5,38 @@ import numpy as np
 from gmprocess.smoothing.konno_ohmachi import konno_ohmachi_smooth
 
 
-def fft_smooth(trace, nfft):
+def fft_smooth(trace, nfft, bandwidth=20):
     """
     Pads a trace to the nearest upper power of 2, takes the FFT, and
     smooths the amplitude spectra following the algorithm of
     Konno and Ohmachi.
 
     Args:
-        trace (obspy.core.trace.Trace): Trace of strong motion data.
-        nfft (int): Number of data points for the fourier transform.
+        trace (StationTrace):
+            Trace of strong motion data.
+        nfft (int):
+            Number of data points for the fourier transform.
+        bandwidth (float):
+            Konno-Omachi smoothing bandwidth parameter.
 
     Returns:
         numpy.ndarray: Smoothed amplitude data and frequencies.
     """
 
     # Compute the FFT, normalizing by the number of data points
-    spec = abs(np.fft.rfft(trace.data, n=nfft)) / nfft
+    dt = trace.stats.delta
+    spec = abs(np.fft.rfft(trace.data, n=nfft)) * dt
 
     # Get the frequencies associated with the FFT
-    freqs = np.fft.rfftfreq(nfft, 1 / trace.stats.sampling_rate)
+    freqs = np.fft.rfftfreq(nfft, dt)
+
     # Do a maximum of 301 K-O frequencies in the range of the fft freqs
     nkofreqs = min(nfft, 302) - 1
     ko_freqs = np.logspace(np.log10(freqs[1]), np.log10(freqs[-1]), nkofreqs)
     # An array to hold the output
     spec_smooth = np.empty_like(ko_freqs)
 
-    # Konno Omachi Smoothing using 20 for bandwidth parameter
-    konno_ohmachi_smooth(spec.astype(np.double), freqs, ko_freqs, spec_smooth,
-                         20.0)
+    # Konno Omachi Smoothing
+    konno_ohmachi_smooth(
+        spec.astype(np.double), freqs, ko_freqs, spec_smooth, bandwidth)
     return spec_smooth, ko_freqs

--- a/gmprocess/fft.py
+++ b/gmprocess/fft.py
@@ -1,0 +1,36 @@
+
+
+import numpy as np
+
+from gmprocess.smoothing.konno_ohmachi import konno_ohmachi_smooth
+
+
+def fft_smooth(trace, nfft):
+    """
+    Pads a trace to the nearest upper power of 2, takes the FFT, and
+    smooths the amplitude spectra following the algorithm of
+    Konno and Ohmachi.
+
+    Args:
+        trace (obspy.core.trace.Trace): Trace of strong motion data.
+        nfft (int): Number of data points for the fourier transform.
+
+    Returns:
+        numpy.ndarray: Smoothed amplitude data and frequencies.
+    """
+
+    # Compute the FFT, normalizing by the number of data points
+    spec = abs(np.fft.rfft(trace.data, n=nfft)) / nfft
+
+    # Get the frequencies associated with the FFT
+    freqs = np.fft.rfftfreq(nfft, 1 / trace.stats.sampling_rate)
+    # Do a maximum of 301 K-O frequencies in the range of the fft freqs
+    nkofreqs = min(nfft, 302) - 1
+    ko_freqs = np.logspace(np.log10(freqs[1]), np.log10(freqs[-1]), nkofreqs)
+    # An array to hold the output
+    spec_smooth = np.empty_like(ko_freqs)
+
+    # Konno Omachi Smoothing using 20 for bandwidth parameter
+    konno_ohmachi_smooth(spec.astype(np.double), freqs, ko_freqs, spec_smooth,
+                         20.0)
+    return spec_smooth, ko_freqs

--- a/gmprocess/pretesting.py
+++ b/gmprocess/pretesting.py
@@ -35,15 +35,14 @@ def check_sta_lta(st, sta_length=1.0, lta_length=20.0, threshold=5.0):
     for tr in st:
         sr = tr.stats.sampling_rate
         nlta = lta_length * sr + 1
-        failed = False
         if len(tr) >= nlta:
             sta_lta = classic_sta_lta(tr, sta_length * sr + 1, nlta)
             if max(sta_lta) < threshold:
-                failed = True
+                tr.fail('Failed sta/lta check because threshold sta/lta '
+                        'is not exceeded.')
         else:
-            failed = True
-        if failed:
-            tr.fail('Failed sta/lta check.')
+            tr.fail('Failed sta/lta check because record length is shorter '
+                    'than lta length.')
 
     return st
 

--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -17,9 +17,10 @@ from gmprocess import corner_frequencies
 # Note: no QA on following import because they need to be in namespace to be
 # discovered. They are not called directly so linters will think this is a
 # mistake.
-from gmprocess.pretesting import (check_max_amplitude,
-                                  check_sta_lta,
-                                  check_free_field)  # NOQA
+from gmprocess.pretesting import (  # NOQA
+    check_max_amplitude,
+    check_sta_lta,
+    check_free_field)
 
 M_TO_CM = 100
 

--- a/gmprocess/snr.py
+++ b/gmprocess/snr.py
@@ -1,0 +1,95 @@
+
+import numpy as np
+
+from obspy.signal.util import next_pow_2
+
+from gmprocess.fft import fft_smooth
+
+
+# Options for tapering noise/signal windows
+TAPER_WIDTH = 0.05
+TAPER_TYPE = 'hann'
+TAPER_SIDE = 'both'
+MIN_POINTS_IN_WINDOW = 10
+
+
+def compute_snr(tr):
+    """Compute SNR dictionaries for a trace.
+
+    Args:
+        tr:
+           StationTrace.
+
+    Returns:
+        StationTrace with SNR dictionaries added as trace parameters.
+    """
+    # Split the noise and signal into two separate traces
+    split_prov = tr.getParameter('signal_split')
+    if isinstance(split_prov, list):
+        split_prov = split_prov[0]
+    split_time = split_prov['split_time']
+    noise = tr.copy().trim(endtime=split_time)
+    signal = tr.copy().trim(starttime=split_time)
+
+    # Taper both windows
+    noise.taper(max_percentage=TAPER_WIDTH,
+                type=TAPER_TYPE,
+                side=TAPER_SIDE)
+    signal.taper(max_percentage=TAPER_WIDTH,
+                 type=TAPER_TYPE,
+                 side=TAPER_SIDE)
+
+    # Need values in both noise and signal windows
+    if noise.stats.npts < MIN_POINTS_IN_WINDOW:
+        tr.fail('Failed SNR check; Not enough points in noise window.')
+        return tr
+    if signal.stats.npts < MIN_POINTS_IN_WINDOW:
+        tr.fail('Failed SNR check; Not enough points in signal window.')
+        return tr
+
+    nfft = max(next_pow_2(signal.stats.npts),
+               next_pow_2(noise.stats.npts))
+
+    # Transform to frequency domain and smooth spectra using
+    # konno-ohmachi smoothing
+    sig_spec = abs(np.fft.rfft(signal.data, n=nfft)) / nfft
+    sig_spec_freqs = np.fft.rfftfreq(nfft, signal.stats.delta)
+    noise_spec = abs(np.fft.rfft(noise.data, n=nfft)) / nfft
+    sig_spec -= noise_spec
+
+    sig_dict = {
+        'spec': sig_spec.tolist(),
+        'freq': sig_spec_freqs.tolist()
+    }
+    tr.setParameter('signal_spectrum', sig_dict)
+
+    noise_dict = {
+        'spec': noise_spec.tolist(),
+        'freq': sig_spec_freqs.tolist()  # same as signal
+    }
+    tr.setParameter('noise_spectrum', noise_dict)
+
+    sig_spec_smooth, freqs_signal = fft_smooth(signal, nfft)
+    smooth_dict = {
+        'spec': sig_spec_smooth.tolist(),
+        'freq': freqs_signal.tolist()
+    }
+    tr.setParameter('smooth_signal_spectrum', smooth_dict)
+
+    noise_spec_smooth, freqs_noise = fft_smooth(noise, nfft)
+    noise_smooth_dict = {
+        'spec': noise_spec_smooth.tolist(),
+        'freq': freqs_noise.tolist()
+    }
+    tr.setParameter('smooth_noise_spectrum', noise_smooth_dict)
+
+    # remove the noise level from the spectrum of the signal window
+    sig_spec_smooth -= noise_spec_smooth
+
+    snr = sig_spec_smooth/noise_spec_smooth
+    snr_dict = {
+        'snr': snr.tolist(),
+        'freq': freqs_signal.tolist()
+    }
+    tr.setParameter('snr', snr_dict)
+    return tr

--- a/gmprocess/snr.py
+++ b/gmprocess/snr.py
@@ -13,12 +13,14 @@ TAPER_SIDE = 'both'
 MIN_POINTS_IN_WINDOW = 10
 
 
-def compute_snr(tr):
+def compute_snr(tr, bandwidth):
     """Compute SNR dictionaries for a trace.
 
     Args:
-        tr:
-           StationTrace.
+        tr (StationTrace):
+           Trace of data.
+        bandwidth (float):
+           Konno-Omachi smoothing bandwidth parameter.
 
     Returns:
         StationTrace with SNR dictionaries added as trace parameters.
@@ -52,9 +54,11 @@ def compute_snr(tr):
 
     # Transform to frequency domain and smooth spectra using
     # konno-ohmachi smoothing
-    sig_spec = abs(np.fft.rfft(signal.data, n=nfft)) / nfft
-    sig_spec_freqs = np.fft.rfftfreq(nfft, signal.stats.delta)
-    noise_spec = abs(np.fft.rfft(noise.data, n=nfft)) / nfft
+    dt = signal.stats.delta
+    sig_spec = abs(np.fft.rfft(signal.data, n=nfft)) * dt
+    sig_spec_freqs = np.fft.rfftfreq(nfft, dt)
+    dt = noise.stats.delta
+    noise_spec = abs(np.fft.rfft(noise.data, n=nfft)) * dt
     sig_spec -= noise_spec
 
     sig_dict = {
@@ -69,7 +73,8 @@ def compute_snr(tr):
     }
     tr.setParameter('noise_spectrum', noise_dict)
 
-    sig_spec_smooth, freqs_signal = fft_smooth(signal, nfft)
+    sig_spec_smooth, freqs_signal = fft_smooth(
+        signal, nfft, bandwidth)
     smooth_dict = {
         'spec': sig_spec_smooth.tolist(),
         'freq': freqs_signal.tolist()

--- a/gmprocess/stationstream.py
+++ b/gmprocess/stationstream.py
@@ -50,9 +50,26 @@ class StationStream(Stream):
                     else:
                         self.append(trace)
 
+    def get_id(self):
+        """
+        Get the StationStream ID.
+        """
+        stats = self.traces[0].stats
+        id_str = "%(network)s.%(station)s.%(location)s" % stats
+
+        # Check that the id would be the same for all traces
+        for tr in self:
+            stats = tr.stats
+            test_str = "%(network)s.%(station)s.%(location)s" % stats
+            if id_str != test_str:
+                raise ValueError(
+                    'Inconsistent stream ID for different traces.')
+        return id_str
+
     @property
     def passed(self):
-        """Check the traces to see if any have failed any processing steps.
+        """
+        Check the traces to see if any have failed any processing steps.
 
         Returns:
             bool: True if no failures in Traces, False if there are.
@@ -91,7 +108,8 @@ class StationStream(Stream):
         return provdocs
 
     def getInventory(self):
-        """Extract an ObsPy inventory object from a Stream read in by gmprocess tools.
+        """
+        Extract an ObsPy inventory object from a Stream read in by gmprocess tools.
         """
         networks = [trace.stats.network for trace in self]
         if len(set(networks)) > 1:

--- a/gmprocess/stationtrace.py
+++ b/gmprocess/stationtrace.py
@@ -229,6 +229,8 @@ class StationTrace(Trace):
             'module': calling_module,
             'reason': reason
         })
+        logging.info(calling_module)
+        logging.info(reason)
 
     def validate(self):
         """Ensure that all required metadata fields have been set.
@@ -517,7 +519,7 @@ class StationTrace(Trace):
         # check for masked array
         if np.ma.count_masked(self.data):
             out += ' (masked)'
-        if self.hasParameter('failed'):
+        if self.hasParameter('failure'):
             out += ' (failed)'
         else:
             out += ' (passed)'

--- a/gmprocess/windows.py
+++ b/gmprocess/windows.py
@@ -22,6 +22,8 @@ from obspy.signal.trigger import ar_pick, pk_baer
 from gmprocess.phase import PowerPicker
 from gmprocess.config import get_config
 
+M_TO_KM = 1.0/1000
+
 
 def window_checks(st, min_noise_duration=0.5, min_signal_duration=5.0):
     """
@@ -136,7 +138,7 @@ def signal_split(
             lat1=event_lat,
             lon1=event_lon,
             lat2=st[0].stats['coordinates']['latitude'],
-            lon2=st[0].stats['coordinates']['longitude'])[0] / 1000.0
+            lon2=st[0].stats['coordinates']['longitude'])[0] * M_TO_KM
         tsplit = event_time + epi_dist / vsplit
         preferred_picker = None
     else:

--- a/tests/gmprocess/corner_frequencies_test.py
+++ b/tests/gmprocess/corner_frequencies_test.py
@@ -1,0 +1,107 @@
+
+import os
+
+import numpy as np
+
+from gmprocess.streamcollection import StreamCollection
+from gmprocess.io.read import read_data
+from gmprocess.io.test_utils import read_data_dir
+from gmprocess.config import get_config
+
+from gmprocess.windows import signal_split
+from gmprocess.windows import signal_end
+from gmprocess.windows import window_checks
+
+from gmprocess.processing import get_corner_frequencies
+from gmprocess.processing import snr_check
+
+
+def test_corner_frequencies():
+    # Default config has 'constant' corner freuqnecy method, so the need
+    # here is to force the 'snr' method.
+    data_files, origin = read_data_dir('geonet', 'us1000778i', '*.V1A')
+    streams = []
+    for f in data_files:
+        streams += read_data(f)
+
+    sc = StreamCollection(streams)
+
+    config = get_config()
+
+    window_conf = config['windows']
+
+    processed_streams = sc.copy()
+    for st in processed_streams:
+        if st.passed:
+            # Estimate noise/signal split time
+            split_conf = window_conf['split']
+            event_time = origin['time']
+            event_lon = origin['lon']
+            event_lat = origin['lat']
+            st = signal_split(
+                st,
+                event_time=event_time,
+                event_lon=event_lon,
+                event_lat=event_lat,
+                **split_conf)
+
+            # Estimate end of signal
+            end_conf = window_conf['signal_end']
+            event_mag = origin['magnitude']
+            st = signal_end(
+                st,
+                event_time=event_time,
+                event_lon=event_lon,
+                event_lat=event_lat,
+                event_mag=event_mag,
+                **end_conf
+            )
+            wcheck_conf = window_conf['window_checks']
+            st = window_checks(
+                st,
+                min_noise_duration=wcheck_conf['min_noise_duration'],
+                min_signal_duration=wcheck_conf['min_signal_duration']
+            )
+
+    pconfig = config['processing']
+
+    # Run SNR check
+    test = [
+        d for d in pconfig if list(d.keys())[0] == 'snr_check'
+    ]
+    snr_config = test[0]['snr_check']
+    for stream in processed_streams:
+        stream = snr_check(
+            stream,
+            **snr_config
+        )
+
+    # Run get_corner_frequencies
+    test = [
+        d for d in pconfig if list(d.keys())[0] == 'get_corner_frequencies'
+    ]
+    cf_config = test[0]['get_corner_frequencies']
+    snr_config = cf_config['snr']
+
+    lp = []
+    hp = []
+    for stream in processed_streams:
+        stream = get_corner_frequencies(
+            stream,
+            method="snr",
+            snr=snr_config
+        )
+        if stream[0].hasParameter('corner_frequencies'):
+            cfdict = stream[0].getParameter('corner_frequencies')
+            lp.append(cfdict['lowpass'])
+            hp.append(cfdict['highpass'])
+    np.testing.assert_allclose(
+        np.sort(hp),
+        np.array([0.0070111, 0.04400637]),
+        atol=1e-6
+    )
+
+
+if __name__ == '__main__':
+    os.environ['CALLED_FROM_PYTEST'] = 'True'
+    test_corner_frequencies()

--- a/tests/gmprocess/processing_test.py
+++ b/tests/gmprocess/processing_test.py
@@ -33,10 +33,7 @@ def test_process_streams():
         'lon': 133.345
     }
 
-    data_files = glob.glob(os.path.join(
-        datadir, 'kiknet', 'usp000a1b0', 'AICH04*'))
     data_files, origin = read_data_dir('geonet', 'us1000778i', '*.V1A')
-    data_files, origin = read_data_dir('kiknet', 'usp000a1b0', 'AICH04*')
     streams = []
     for f in data_files:
         streams += read_data(f)
@@ -49,8 +46,10 @@ def test_process_streams():
 
     logging.info('Testing trace: %s' % test[0][1])
 
-    assert len(test) == 1
+    assert len(test) == 3
     assert len(test[0]) == 3
+    assert len(test[1]) == 3
+    assert len(test[2]) == 3
 
     # Apparently the traces end up in a different order on the Travis linux
     # container than on my local mac. So testing individual traces need to
@@ -60,7 +59,7 @@ def test_process_streams():
 
     np.testing.assert_allclose(
         trace_maxes,
-        np.array([5.02085686,  9.11140442, 10.74934006]),
+        np.array([157.82909426, 240.36582093, 263.7063879]),
         rtol=1e-5
     )
 
@@ -87,12 +86,12 @@ def test_free_field():
                 reason = trace.getParameter('failure')['reason']
                 break
         if is_free:
-            assert reason == 'Failed sta/lta check.'
+            assert reason.startswith('Failed sta/lta check')
         else:
             assert reason == 'Failed free field sensor check.'
 
 
 if __name__ == '__main__':
     os.environ['CALLED_FROM_PYTEST'] = 'True'
-    test_free_field()
     test_process_streams()
+    test_free_field()

--- a/tests/gmprocess/processing_test.py
+++ b/tests/gmprocess/processing_test.py
@@ -56,19 +56,17 @@ def test_process_streams():
     # container than on my local mac. So testing individual traces need to
     # not care about trace order.
 
-    trace_maxes = np.sort([np.max(t.data) for t in test[0]])
+    trace_maxes = np.sort([np.max(np.abs(t.data)) for t in test[0]])
 
     np.testing.assert_allclose(
         trace_maxes,
-        np.array([1.30994939, 3.36651873, 4.87532321]),
+        np.array([5.02085686,  9.11140442, 10.74934006]),
         rtol=1e-5
     )
 
 
 def test_free_field():
     data_files, origin = read_data_dir('kiknet', 'usp000hzq8')
-
-    config = get_config()
 
     raw_streams = []
     for dfile in data_files:

--- a/tests/gmprocess/spectrum_test.py
+++ b/tests/gmprocess/spectrum_test.py
@@ -9,8 +9,8 @@ def test_spectrum():
     freq = np.logspace(-2, 2, 101)
     mod = spectrum.model(freq, 10, kappa=0.035, magnitude=6.7)
     np.testing.assert_allclose(mod[0], 0.21764373, atol=1e-5)
-    np.testing.assert_allclose(mod[50], 113.234943, atol=1e-5)
-    np.testing.assert_allclose(mod[-1], 0.00322216, atol=1e-5)
+    np.testing.assert_allclose(mod[50], 113.5025146, atol=1e-5)
+    np.testing.assert_allclose(mod[-1], 0.0032295, atol=1e-5)
 
 
 def test_fff():


### PR DESCRIPTION
Note: the new plotting method has only undergone limited testing and there are probably some problems that will come up as it gets used with a wider range of data.

This PR includes lots of stuff, including:
- moved sta/lta checks to occur earlier in the default processing steps
- generally made things more modular (e.g., now we have 'fft.py' and 'snr.py' modules)
- changed scaling of fft
- corner frequency selection step is now not handled "specially"; it is just treated generically like most other processing steps
- adjusted processing.py to allow for steps with empty options
- made adjustments so summary plots can be made for all traces, regardless of check passes/failures, and refactored so that it makes more use of trace parameters for information rather than function arguments
- added get_id for stationstream
- separated out Brune corner method to use it fitting spectra
- added fit_spectra step to processing
- fixed bug where the config smoothing bandwidth wasn't getting used in the Konno-Omachi method
- tried to put all traces for a given StationStream on one plot; this will be problematic if there are more than three traces perstream
