### PR TITLE
Plot tweaks

### DIFF
--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -89,8 +89,8 @@ windows:
 # recorded as seismological provenance data.
 processing:
 
-    # Check to keep or ignore non-free-field sensors. Typically, these include sensors
-    # attached to a large structure (buildings, dams, bridges, etc.)
+    # Check to keep or ignore non-free-field sensors. Typically, these include
+    # sensors attached to a large structure (buildings, dams, bridges, etc.)
     - check_free_field:
         reject_non_free_field: True
 
@@ -100,6 +100,12 @@ processing:
     - check_max_amplitude:
         min: 5
         max: 2e6
+
+    # Apply a maximum number of traces per stream. This can occur with downhole
+    # or structural arrays since our code currently is not able to reliably
+    # group by location within an array.
+    - max_traces:
+        n_max: 3
 
 
     # STA/LTA is computed for record and the max value must exceed the threshold

--- a/gmprocess/stationstream.py
+++ b/gmprocess/stationstream.py
@@ -53,14 +53,22 @@ class StationStream(Stream):
     def get_id(self):
         """
         Get the StationStream ID.
+
+        This consists of the network, station, and first two characters of the
+        channel (to indicate instrument type). This is currently consistent
+        with how the channels are grouped by StationStrea and ignores the
+        location code because it doesn't seem like it is defined in a
+        consistent fashion.
         """
         stats = self.traces[0].stats
-        id_str = "%(network)s.%(station)s.%(location)s" % stats
+        id_str = ("%s.%s.%s" %
+                  (stats.network, stats.station, stats.channel[0:2]))
 
         # Check that the id would be the same for all traces
         for tr in self:
             stats = tr.stats
-            test_str = "%(network)s.%(station)s.%(location)s" % stats
+            test_str = ("%s.%s.%s" %
+                        (stats.network, stats.station, stats.channel[0:2]))
             if id_str != test_str:
                 raise ValueError(
                     'Inconsistent stream ID for different traces.')

--- a/tests/gmprocess/io/asdf/stream_workspace_test.py
+++ b/tests/gmprocess/io/asdf/stream_workspace_test.py
@@ -276,7 +276,7 @@ def test_raw():
             x = 1
 
         except Exception as e:
-            assert 1 == 2
+            raise e
         finally:
             shutil.rmtree(tdir)
 


### PR DESCRIPTION
- added a max_traces processing step to screen out StationStreams that have more than 3 stations.
- modified StationStream.get_id to not make use of location code; uses first two characters of the channel code instead.
- modify summary_plot to indicate if a trace has failed any tests


Decided to wait on adding the stream check failure reason text until we have a better solution for putting tabular information into the page, perhaps via embedding the figure into a latex document. 

We might want to reconsider not doing some of the processing steps even when the stream has been rejected.