### PR TITLE
Reorganize status checks

### DIFF
--- a/gmprocess/pretesting.py
+++ b/gmprocess/pretesting.py
@@ -6,12 +6,27 @@ Pretesting methods.
 from obspy.signal.trigger import classic_sta_lta
 
 
-def check_free_field(stream, reject_non_free_field=False):
-    for trace in stream:
+def check_free_field(st, reject_non_free_field=False):
+    """
+    Checks free field status of stream.
+
+    Args:
+        st (obspy.core.stream.Stream):
+            Stream of data.
+        reject_non_free_field (bool):
+            Should non free-field stations be failed?
+
+    Returns:
+        Stream that has been checked for free field status.
+    """
+    if not st.passed:
+        return st
+
+    for trace in st:
         if not trace.free_field and reject_non_free_field:
             trace.fail('Failed free field sensor check.')
 
-    return stream
+    return st
 
 
 def check_sta_lta(st, sta_length=1.0, lta_length=20.0, threshold=5.0):
@@ -30,8 +45,11 @@ def check_sta_lta(st, sta_length=1.0, lta_length=20.0, threshold=5.0):
             Required maximum STA/LTA ratio to pass the test.
 
     Returns:
-        bool: Did the stream pass the check?
+        Stream that has been checked for sta/lta requirements.
     '''
+    if not st.passed:
+        return st
+
     for tr in st:
         sr = tr.stats.sampling_rate
         nlta = lta_length * sr + 1
@@ -61,8 +79,11 @@ def check_max_amplitude(st, min=5, max=2e6):
             Maximum amplitude for the acceptable range. Default is 2e6.
 
     Returns:
-        bool: Did the stream pass the check?
+        Stream that has been checked for maximum amplitude criteria.
     """
+    if not st.passed:
+        return st
+
     for tr in st:
         if isinstance(tr.data[0], int):
             if (abs(tr.max()) < float(min) or

--- a/gmprocess/snr.py
+++ b/gmprocess/snr.py
@@ -25,76 +25,124 @@ def compute_snr(tr, bandwidth):
     Returns:
         StationTrace with SNR dictionaries added as trace parameters.
     """
-    # Split the noise and signal into two separate traces
-    split_prov = tr.getParameter('signal_split')
-    if isinstance(split_prov, list):
-        split_prov = split_prov[0]
-    split_time = split_prov['split_time']
-    noise = tr.copy().trim(endtime=split_time)
-    signal = tr.copy().trim(starttime=split_time)
+    # Do we have estimates of the signal split time?
+    if tr.hasParameter('signal_split'):
+        # Split the noise and signal into two separate traces
+        split_prov = tr.getParameter('signal_split')
+        if isinstance(split_prov, list):
+            split_prov = split_prov[0]
+        split_time = split_prov['split_time']
+        noise = tr.copy().trim(endtime=split_time)
+        signal = tr.copy().trim(starttime=split_time)
 
-    # Taper both windows
-    noise.taper(max_percentage=TAPER_WIDTH,
-                type=TAPER_TYPE,
-                side=TAPER_SIDE)
-    signal.taper(max_percentage=TAPER_WIDTH,
-                 type=TAPER_TYPE,
-                 side=TAPER_SIDE)
+        # Taper both windows
+        noise.taper(max_percentage=TAPER_WIDTH,
+                    type=TAPER_TYPE,
+                    side=TAPER_SIDE)
+        signal.taper(max_percentage=TAPER_WIDTH,
+                     type=TAPER_TYPE,
+                     side=TAPER_SIDE)
 
-    # Need values in both noise and signal windows
-    if noise.stats.npts < MIN_POINTS_IN_WINDOW:
-        tr.fail('Failed SNR check; Not enough points in noise window.')
-        return tr
-    if signal.stats.npts < MIN_POINTS_IN_WINDOW:
-        tr.fail('Failed SNR check; Not enough points in signal window.')
-        return tr
+        # Check that there are a minimum number of points in the noise window
+        if noise.stats.npts < MIN_POINTS_IN_WINDOW:
+            # Fail the trace, but still compute the signal spectra
+            # ** only fail here if it hasn't already failed; we do not yet
+            # ** support tracking multiple fail reasons and I think it is
+            # ** better to know the FIRST reason if I have to pick one.
+            if not tr.hasParameter('failure'):
+                tr.fail('Failed SNR check; Not enough points in noise window.')
+            tr = compute_signal_spectrum(tr, bandwidth)
+            return tr
 
-    nfft = max(next_pow_2(signal.stats.npts),
-               next_pow_2(noise.stats.npts))
+        # Check that there are a minimum number of points in the noise window
+        if signal.stats.npts < MIN_POINTS_IN_WINDOW:
+            # Fail the trace, but still compute the signal spectra
+            if not tr.hasParameter('failure'):
+                tr.fail(
+                    'Failed SNR check; Not enough points in signal window.')
+            tr = compute_signal_spectrum(tr, bandwidth)
+            return tr
 
+        nfft = max(next_pow_2(signal.stats.npts),
+                   next_pow_2(noise.stats.npts))
+
+        # Transform to frequency domain and smooth spectra using
+        # konno-ohmachi smoothing
+        dt = signal.stats.delta
+        sig_spec = abs(np.fft.rfft(signal.data, n=nfft)) * dt
+        sig_spec_freqs = np.fft.rfftfreq(nfft, dt)
+        dt = noise.stats.delta
+        noise_spec = abs(np.fft.rfft(noise.data, n=nfft)) * dt
+        sig_spec -= noise_spec
+
+        sig_dict = {
+            'spec': sig_spec.tolist(),
+            'freq': sig_spec_freqs.tolist()
+        }
+        tr.setParameter('signal_spectrum', sig_dict)
+
+        noise_dict = {
+            'spec': noise_spec.tolist(),
+            'freq': sig_spec_freqs.tolist()  # same as signal
+        }
+        tr.setParameter('noise_spectrum', noise_dict)
+
+        sig_spec_smooth, freqs_signal = fft_smooth(
+            signal, nfft, bandwidth)
+        smooth_dict = {
+            'spec': sig_spec_smooth.tolist(),
+            'freq': freqs_signal.tolist()
+        }
+        tr.setParameter('smooth_signal_spectrum', smooth_dict)
+
+        noise_spec_smooth, freqs_noise = fft_smooth(noise, nfft)
+        noise_smooth_dict = {
+            'spec': noise_spec_smooth.tolist(),
+            'freq': freqs_noise.tolist()
+        }
+        tr.setParameter('smooth_noise_spectrum', noise_smooth_dict)
+
+        # remove the noise level from the spectrum of the signal window
+        sig_spec_smooth -= noise_spec_smooth
+
+        snr = sig_spec_smooth/noise_spec_smooth
+        snr_dict = {
+            'snr': snr.tolist(),
+            'freq': freqs_signal.tolist()
+        }
+        tr.setParameter('snr', snr_dict)
+    else:
+        # We do not have an estimate of the signal split time for this trace
+        tr = compute_signal_spectrum(tr, bandwidth)
+    return tr
+
+
+def compute_signal_spectrum(tr, bandwidth):
+    """
+    Compute raw and smoothed signal spectrum.
+
+    Args:
+        tr (StationTrace):
+           Trace of data.
+        bandwidth (float):
+           Konno-Omachi smoothing bandwidth parameter.
+
+    Returns:
+        StationTrace with signal spectrum dictionaries added as trace
+        parameters.
+
+    """
     # Transform to frequency domain and smooth spectra using
     # konno-ohmachi smoothing
-    dt = signal.stats.delta
-    sig_spec = abs(np.fft.rfft(signal.data, n=nfft)) * dt
+    nfft = next_pow_2(tr.stats.npts)
+
+    dt = tr.stats.delta
+    sig_spec = abs(np.fft.rfft(tr.data, n=nfft)) * dt
     sig_spec_freqs = np.fft.rfftfreq(nfft, dt)
-    dt = noise.stats.delta
-    noise_spec = abs(np.fft.rfft(noise.data, n=nfft)) * dt
-    sig_spec -= noise_spec
 
     sig_dict = {
         'spec': sig_spec.tolist(),
         'freq': sig_spec_freqs.tolist()
     }
     tr.setParameter('signal_spectrum', sig_dict)
-
-    noise_dict = {
-        'spec': noise_spec.tolist(),
-        'freq': sig_spec_freqs.tolist()  # same as signal
-    }
-    tr.setParameter('noise_spectrum', noise_dict)
-
-    sig_spec_smooth, freqs_signal = fft_smooth(
-        signal, nfft, bandwidth)
-    smooth_dict = {
-        'spec': sig_spec_smooth.tolist(),
-        'freq': freqs_signal.tolist()
-    }
-    tr.setParameter('smooth_signal_spectrum', smooth_dict)
-
-    noise_spec_smooth, freqs_noise = fft_smooth(noise, nfft)
-    noise_smooth_dict = {
-        'spec': noise_spec_smooth.tolist(),
-        'freq': freqs_noise.tolist()
-    }
-    tr.setParameter('smooth_noise_spectrum', noise_smooth_dict)
-
-    # remove the noise level from the spectrum of the signal window
-    sig_spec_smooth -= noise_spec_smooth
-
-    snr = sig_spec_smooth/noise_spec_smooth
-    snr_dict = {
-        'snr': snr.tolist(),
-        'freq': freqs_signal.tolist()
-    }
-    tr.setParameter('snr', snr_dict)
     return tr

--- a/gmprocess/spectrum.py
+++ b/gmprocess/spectrum.py
@@ -66,8 +66,10 @@ def fit_spectra(st, origin, kappa=0.035):
         StationStream with fitted spectra parameters.
     """
     for tr in st:
-        # Only do this for horizontal channels
-        if 'Z' not in tr.stats['channel'].upper():
+        # Only do this for horizontal channels for which the smoothed spectra
+        # has been computed.
+        if ('Z' not in tr.stats['channel'].upper()) & \
+                tr.hasParameter('smooth_signal_spectrum'):
             event_mag = origin['magnitude']
             event_lon = origin['lon']
             event_lat = origin['lat']

--- a/gmprocess/stationstream.py
+++ b/gmprocess/stationstream.py
@@ -1,5 +1,6 @@
 # stdlib imports
 import json
+import logging
 
 # third party imports
 import numpy as np
@@ -145,6 +146,7 @@ class StationStream(Stream):
         )
         channels = []
         for trace in self:
+            logging.debug('trace: %s' % trace)
             channel = _channel_from_stats(trace.stats)
             channels.append(channel)
 
@@ -218,6 +220,7 @@ def _channel_from_stats(stats):
     if 'response' in stats:
         response = stats['response']
     comments = Comment(stats.standard.comments)
+    logging.debug('channel: %s' % stats.channel)
     channel = Channel(stats.channel,
                       stats.location,
                       stats.coordinates['latitude'],

--- a/tests/gmprocess/corner_frequencies_test.py
+++ b/tests/gmprocess/corner_frequencies_test.py
@@ -48,6 +48,7 @@ def test_corner_frequencies():
             # Estimate end of signal
             end_conf = window_conf['signal_end']
             event_mag = origin['magnitude']
+            print(st)
             st = signal_end(
                 st,
                 event_time=event_time,


### PR DESCRIPTION
Move `stream.passed` check inside processing step methods, rather than outer `process_streams`. This is to allow some steps to occur regardless of whether or not the stream has passed checks (such as computing the signal spectrum, which would be nice to have in the summary plots even if a check has failed). I also expect that some steps might eventually have the ability to "un-fail" a stream. For example, if the noise windowing fails, but we are able to pick reasonable corner frequencies solely on the signal spectra. This will require a failure status system that is a bit more complicated than what we are currently doing because other checks should not be allowed to be "undone" by downstream steps, such as the free field check.