### PR TITLE
Instrument response correction fix for strong motion instruments.

### DIFF
--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -217,6 +217,13 @@ def remove_response(st, f1, f2, f3=None, f4=None, water_level=None,
 
     # Check if the response information is already attached in the trace stats
     for tr in st:
+
+        # Check if this trace has already been converted to physical units
+        if 'remove_response' in tr.getProvenanceKeys():
+            logging.info('Trace has already had instrument response removed. '
+                         'Nothing to be done.')
+            continue
+
         f_n = 0.5 / tr.stats.delta
         if f3 is None:
             f3 = 0.9 * f_n
@@ -241,19 +248,15 @@ def remove_response(st, f1, f2, f3=None, f4=None, water_level=None,
                 }
             )
         elif tr.stats.channel[1] == 'N':
-            if isinstance(tr.data[0], int):
-                tr.remove_sensitivity(inventory=inv)
-                tr.data *= M_TO_CM  # Convert from m/s/s to cm/s/s
-                tr.setProvenance(
-                    'remove_response',
-                    {
-                        'method': 'remove_sensitivity',
-                        'inventory': inv
-                    }
-                )
-            else:
-                logging.info('Skipping sensitivity removal because units '
-                             'are not counts (integers).')
+            tr.remove_sensitivity(inventory=inv)
+            tr.data *= M_TO_CM  # Convert from m/s/s to cm/s/s
+            tr.setProvenance(
+                'remove_response',
+                {
+                    'method': 'remove_sensitivity',
+                    'inventory': inv
+                }
+            )
         else:
             reason = ('This instrument type is not supported. '
                       'The instrument code must be either H '


### PR DESCRIPTION
Instrument response removal was only performed for strong motion instruments when the data was in integers. However, uncorrected data will not always be in integers (such as if the data has been demeaned). Instrument response correction will now check if a provenance entry ('remove_response') has already been set before removing response.