### PR TITLE
Misc

### DIFF
--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -107,6 +107,11 @@ processing:
     - max_traces:
         n_max: 3
 
+    - detrend:
+        # Supported obspy methods (besides the baseline described below):
+        #     constant, demean, linear, polynomial, simple, spline
+        detrending_method: demean
+
 
     # STA/LTA is computed for record and the max value must exceed the threshold
     # below. Units are sec for window lenghts.

--- a/gmprocess/phase.py
+++ b/gmprocess/phase.py
@@ -187,7 +187,7 @@ def pick_kalkan(stream, picker_config=None, config=None):
                     window_checks:
                         min_noise_duration
     Returns:
-        tuple: 
+        tuple:
             - Best estimate for p-wave arrival time (s since start of trace).
             - Mean signal to noise ratio based on the pick.
     """
@@ -230,7 +230,7 @@ def pick_ar(stream, picker_config=None, config=None):
                     window_checks:
                         min_noise_duration
     Returns:
-        tuple: 
+        tuple:
             - Best estimate for p-wave arrival time (s since start of trace).
             - Mean signal to noise ratio based on the pick.
     """
@@ -276,7 +276,7 @@ def pick_baer(stream, picker_config=None, config=None):
                     window_checks:
                         min_noise_duration
     Returns:
-        tuple: 
+        tuple:
             - Best estimate for p-wave arrival time (s since start of trace).
             - Mean signal to noise ratio based on the pick.
     """
@@ -314,7 +314,7 @@ def pick_yeck(stream):
         stream (StationStream):
             Stream containing waveforms that need to be picked.
     Returns:
-        tuple: 
+        tuple:
             - Best estimate for p-wave arrival time (s since start of trace).
             - Mean signal to noise ratio based on the pick.
     """
@@ -363,7 +363,7 @@ def pick_power(stream, picker_config=None, config=None):
                     window_checks:
                         min_noise_duration
     Returns:
-        tuple: 
+        tuple:
             - Best estimate for p-wave arrival time (s since start of trace).
             - Mean signal to noise ratio based on the pick.
     """
@@ -435,15 +435,15 @@ def calc_snr(stream, minloc):
 
     Returns:
         float:
-            Ratio of signal window (minloc->end of trace) over 
+            Ratio of signal window (minloc->end of trace) over
             noise window (start of trace->minloc)
 
     """
     snr_values = []
     for trace in stream:
         dt = trace.stats.delta
-        signal = trace.data
-        noise = trace.data[0:int(minloc / dt)]
+        signal = np.array(trace.data, dtype=float)
+        noise = np.array(trace.data, dtype=float)[0:int(minloc / dt)]
         aps = np.mean(np.power(signal, 2))  # average power of signal
         apn = np.mean(np.power(noise, 2))   # average power of noise
         if apn == 0:

--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -215,8 +215,6 @@ def remove_response(st, f1, f2, f3=None, f4=None, water_level=None,
     Returns:
         StationStream: Instrument-response-corrected stream.
     """
-    if not st.passed:
-        return st
 
     if output not in ['ACC', 'VEL', 'DISP']:
         raise ValueError('Output value of %s is invalid. Must be ACC, VEL, '
@@ -291,8 +289,6 @@ def detrend(st, detrending_method=None):
     Returns:
         StationStream: Detrended stream.
     """
-    if not st.passed:
-        return st
 
     for tr in st:
         if detrending_method == 'baseline_sixth_order':

--- a/gmprocess/report.py
+++ b/gmprocess/report.py
@@ -31,8 +31,9 @@ PREAMBLE = """
 \\usepackage[letterpaper, portrait]{geometry}
 
 \\geometry{
-   left=0.5in,
+   left=0.75in,
    top=0.5in,
+   total={7in,10in}
 }
 
 \setlength\parindent{0pt}
@@ -49,10 +50,6 @@ STREAMBLOCK = """
     {[PLOTPATH]}
 
 """
-
-BEGIN_COL = """\\begin{minipage}[t]{%s\\textwidth} \\scriptsize \\centering"""
-
-END_COL = """\\end{minipage}"""
 
 
 def build_report(sc, directory, origin, config=None):
@@ -93,32 +90,17 @@ def build_report(sc, directory, origin, config=None):
 
         prov_latex = get_prov_latex(st)
 
-        # for i, tr in enumerate(st):
-        #     # Disallow more than three columns
-        #     if i > 2:
-        #         break
-        #     if i == 0:
-        #         prov_latex = get_prov_latex(tr)
-        #         report += BEGIN_COL % "0.4"
-        #     else:
-        #         prov_latex = get_prov_latex(tr, include_prov_id=False)
-        #         report += BEGIN_COL % "0.27"
-        #     report += prov_latex
-        #     if tr.hasParameter('failure'):
-        #         report += '\n' + tr.getParameter('failure')['reason']
-        #     report += END_COL
-        #     if i < len(st):
-        #         report += '\\hspace{2em}'
         report += prov_latex
         if st[0].hasParameter('signal_split'):
             pick_method = st[0].getParameter('signal_split')['picker_type']
-            report += '\n' + 'Pick Method: %s\n' % pick_method
+            report += '\n' + 'Pick Method: %s\n\n' % pick_method
         if not st.passed:
             for tr in st:
                 if tr.hasParameter('failure'):
-                    report += '\n' + tr.getParameter('failure')['reason']
+                    report += ('Failure reason: %s\n\n'
+                               % tr.getParameter('failure')['reason'])
                     break
-        report += '\n\\newpage\n\n'
+        report += '\\newpage\n\n'
 
     # Finish the latex file
     report += POSTAMBLE
@@ -178,7 +160,7 @@ def get_prov_latex(st):
 
     newdf = newdf.drop(labels='Index', axis='columns')
     prov_string = newdf.to_latex(index=False)
-    prov_string = '\\scriptsize\n\\centering\n' + prov_string
+    prov_string = '\\scriptsize\n' + prov_string
     return prov_string
 
 

--- a/gmprocess/windows.py
+++ b/gmprocess/windows.py
@@ -21,7 +21,6 @@ from obspy.geodetics.base import gps2dist_azimuth
 
 from gmprocess.phase import (pick_power, pick_ar, pick_baer, pick_kalkan)
 from gmprocess.config import get_config
-from gmprocess.exception import GMProcessException
 
 M_TO_KM = 1.0 / 1000
 
@@ -124,7 +123,7 @@ def signal_split(
                                                 config=config)
                 elif pick_method == 'yeck':
                     loc, mean_snr = pick_kalkan(st)
-            except GMProcessException:
+            except Exception:
                 loc = -1
                 mean_snr = np.nan
             row = {'Stream': st.get_id(),

--- a/tests/gmprocess/processing_test.py
+++ b/tests/gmprocess/processing_test.py
@@ -83,7 +83,7 @@ def test_free_field():
                 reason = trace.getParameter('failure')['reason']
                 break
         if is_free:
-            assert reason.startswith('Failed sta/lta check')
+            assert reason.startswith('Failed')
         else:
             assert reason == 'Failed free field sensor check.'
 


### PR DESCRIPTION
- minor tweaks to report
- always detrend and correct response, even if qa checks fail so velocity trace doesn't look absurd in report
-  moved detrend step before instrument correction in default config file
- fix bug where square of squaring of an integer results in overflow error
- Broadened windows exception catch so that processing continues when a picker might fail for various reasons