### PR TITLE
event.get_event_object() needs to set time attribute.

### DIFF
--- a/gmprocess/event.py
+++ b/gmprocess/event.py
@@ -53,6 +53,7 @@ def get_event_object(dict_or_id):
     origin.latitude = event_dict['lat']
     origin.longitude = event_dict['lon']
     origin.depth = event_dict['depth']
+    origin.time = event_dict['time']
 
     magnitude = Magnitude(mag=event_dict['magnitude'])
     event = Event()

--- a/tests/gmprocess/event_test.py
+++ b/tests/gmprocess/event_test.py
@@ -18,12 +18,16 @@ def test_event():
                  'lat': -14.7132,
                  'lon': -70.1375,
                  'depth': 267,
-                 'magnitude': 7}
+                 'magnitude': 7.0}
         assert edict == tdict
 
         event = get_event_object(eid)
-        assert event.resource_id.id == 'us1000j96d'
+        assert event.resource_id.id == eid
         assert event.magnitudes[0].mag == 7.0
+        assert event.origins[0].time == UTCDateTime(2019, 3, 1, 8, 50, 42, 570000)
+        assert event.origins[0].latitude == -14.7132
+        assert event.origins[0].longitude == -70.1375
+        assert event.origins[0].depth == 267
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The event.get_event_object() in creating an Origin object from a dict
needs to transfer the origin time from the dict to the Origin object.

event_test.py needs to be updated to be more rigorous.