### PR TITLE
Misc updates

### DIFF
--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -14,7 +14,7 @@ from gmprocess.stationtrace import StationTrace, TIMEFMT_MS
 from gmprocess.stationstream import StationStream
 from gmprocess.streamcollection import StreamCollection
 from gmprocess.metrics.station_summary import StationSummary
-from gmprocess.streamcollection import StreamCollection
+from gmprocess.exception import GMProcessException
 
 TIMEPAT = '[0-9]{4}-[0-9]{2}-[0-9]{2}T'
 
@@ -24,7 +24,8 @@ class StreamWorkspace(object):
         """Create an ASDF file given an Event and list of StationStreams.
 
         Args:
-            filename (str): Path to ASDF file to create.
+            filename (str):
+                Path to ASDF file to create.
         """
         if not exists:
             compression = "gzip-3"
@@ -81,11 +82,20 @@ class StreamWorkspace(object):
         """Add a sequence of StationStream objects to an ASDF file.
 
         Args:
-            event (Event): Obspy event object.
-            streams (list): List of StationStream objects.
-            label (str): Label to attach to stream sequence.
+            event (Event):
+                Obspy event object.
+            streams (list):
+                List of StationStream objects.
+            label (str):
+                Label to attach to stream sequence. Cannot contain an
+                underscore.
         """
-        # to allow for multiple processed versions of the same Stream
+        if label is not None:
+            if '_' in label:
+                raise GMProcessException(
+                    'Stream label cannot contain an underscore.')
+
+        # To allow for multiple processed versions of the same Stream
         # let's keep a dictionary of stations and sequence number.
         eventid = _get_id(event)
         if not self.hasEvent(eventid):
@@ -170,14 +180,19 @@ class StreamWorkspace(object):
         return labels
 
     def getStreamTags(self, eventid, label=None):
-        """Get list of Stream "tags" which can be used to retrieve individual streams.
+        """
+        Get list of Stream "tags" which can be used to retrieve individual
+        streams.
 
         Args:
-            eventid (str): Event ID corresponding to a sequence of Streams.
-            label (str): Optional stream label assigned with addStreams().
+            eventid (str):
+                Event ID corresponding to a sequence of Streams.
+            label (str):
+                Optional stream label assigned with addStreams().
 
         Returns:
-            list: Sequence of strings indicating Stream tags corresponding to eventid.
+            list: Sequence of strings indicating Stream tags corresponding to
+            eventid.
         """
         if not self.hasEvent(eventid):
             fmt = 'Event with a resource id containing %s could not be found.'
@@ -209,7 +224,8 @@ class StreamWorkspace(object):
                 List of processing labels to search for.
 
         Returns:
-            StreamCollection: Object containing list of organized StationStreams.
+            StreamCollection: Object containing list of organized
+            StationStreams.
         """
         auxholder = []
         if 'ProcessingParameters' in self.dataset.auxiliary_data:
@@ -416,7 +432,9 @@ class StreamWorkspace(object):
         return summary
 
     def summarizeLabels(self):
-        """Summarize the processing metadata associated with each label in the file.
+        """
+        Summarize the processing metadata associated with each label in the
+        file.
 
         Returns:
             DataFrame:
@@ -424,7 +442,8 @@ class StreamWorkspace(object):
                     - Label Processing label.
                     - UserID user id (i.e., jsmith)
                     - UserName Full user name (i.e., Jane Smith) (optional)
-                    - UserEmail Email adress (i.e., jsmith@awesome.org) (optional)
+                    - UserEmail Email adress (i.e., jsmith@awesome.org)
+                      (optional)
                     - Software Name of processing software (i.e., gmprocess)
                     - Version Version of software (i.e., 1.4)
 

--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -395,7 +395,11 @@ def cut(st, sec_before_split=None):
             split_time = tr.getParameter('signal_split')['split_time']
             stime = split_time - sec_before_split
             logging.debug('Before cut start time: %s ' % tr.stats.starttime)
-            tr.trim(starttime=stime)
+            if stime < etime:
+                tr.trim(starttime=stime)
+            else:
+                tr.fail('The \'cut\' processing step resulting in '
+                        'incompatible start and end times.')
             logging.debug('After cut start time: %s ' % tr.stats.starttime)
         tr.setProvenance(
             'cut',

--- a/tests/gmprocess/io/asdf/stream_workspace_test.py
+++ b/tests/gmprocess/io/asdf/stream_workspace_test.py
@@ -13,8 +13,6 @@ from gmprocess.config import get_config
 from gmprocess.io.test_utils import read_data_dir
 from gmprocess.event import get_event_object
 from gmprocess.streamcollection import StreamCollection
-from gmprocess.io.fdsn.fdsn_fetcher import FDSNFetcher
-from gmprocess.event import get_event_dict
 
 from h5py.h5py_warnings import H5pyDeprecationWarning
 from yaml import YAMLLoadWarning
@@ -223,90 +221,6 @@ def test_workspace():
         shutil.rmtree(tdir)
 
 
-def test_raw():
-    tdir = tempfile.mkdtemp()
-    try:
-        datafiles, origin = read_data_dir('fdsn', 'nc72282711', '*.mseed')
-        streams = []
-        for datafile in datafiles:
-            streams += read_data(datafile)
-
-        streams = StreamCollection(streams)
-        eventobj = get_event_object(origin)
-
-        tfile = os.path.join(tdir, 'test.hdf')
-        workspace = StreamWorkspace(tfile)
-        workspace.addStreams(eventobj, streams, label='raw')
-
-        tstreams = workspace.getStreams(origin['id'])
-        assert len(tstreams) == 0
-
-        raw_streams = workspace.getStreams(origin['id'], get_raw=True)
-        assert len(raw_streams) == len(streams)
-    except Exception as e:
-        raise e
-    finally:
-        shutil.rmtree(tdir)
-
-    # msg = "dataset.value has been deprecated. Use dataset[()] instead."
-    # with warnings.catch_warnings():
-    #     warnings.filterwarnings("ignore", category=H5pyDeprecationWarning)
-    #     warnings.filterwarnings("ignore", category=YAMLLoadWarning)
-    #     warnings.filterwarnings("ignore", category=FutureWarning)
-    #     raw_streams, inv = request_raw_waveforms(
-    #         fdsn_client='IRIS',
-    #         org_time='2018-11-30T17-29-29.330Z',
-    #         lat=61.3464,
-    #         lon=-149.9552,
-    #         before_time=120,
-    #         after_time=120,
-    #         dist_min=0,
-    #         dist_max=0.135,
-    #         networks='*',
-    #         stations='*',
-    #         channels=['?N?'],
-    #         access_restricted=False)
-    #     tdir = tempfile.mkdtemp()
-    #     try:
-    #         edict = get_event_dict('ak20419010')
-    #         origin = get_event_object('ak20419010')
-    #         tfile = os.path.join(tdir, 'test.hdf')
-    #         sc1 = StreamCollection(raw_streams)
-    #         workspace = StreamWorkspace(tfile)
-    #         workspace.addStreams(origin, sc1, label='raw')
-    #         tstreams = workspace.getStreams(edict['id'])
-    #         assert len(tstreams) == 0
-
-    #         imclist = ['greater_of_two_horizontals',
-    #                    'channels',
-    #                    'rotd50',
-    #                    'rotd100']
-    #         imtlist = ['sa1.0', 'PGA', 'pgv', 'fas2.0', 'arias']
-    #         # this shouldn't do anything
-    #         workspace.setStreamMetrics(edict['id'],
-    #                                    imclist=imclist, imtlist=imtlist)
-
-    #         processed_streams = process_streams(sc1, edict)
-    #         workspace.addStreams(origin, processed_streams, 'processed')
-    #         labels = workspace.getLabels()
-    #         tags = workspace.getStreamTags(edict['id'])
-    #         out_raw_streams = workspace.getStreams(edict['id'], get_raw=True)
-    #         assert len(out_raw_streams) == len(sc1)
-
-    #         # this should only work on processed data
-    #         workspace.setStreamMetrics(edict['id'],
-    #                                    imclist=imclist, imtlist=imtlist)
-
-    #         df = workspace.summarizeLabels()
-    #         x = 1
-
-    #     except Exception as e:
-    #         raise e
-    #     finally:
-    #         shutil.rmtree(tdir)
-
-
 if __name__ == '__main__':
     os.environ['CALLED_FROM_PYTEST'] = 'True'
-    test_raw()
     test_workspace()


### PR DESCRIPTION
- Added provenance logging when StationStream trims record (this is in the init and thus is not part of the processing steps where logging is more reliably handled).
- Detect if the trim is going to cause an error in ObsPy so that we can fail the trace rather than raise an exception that halts processing from proceeding.
- Fixed bug in StationStream where it can't find a tag for an empty StationStream. 
- Improved handling of tag in StreamCollection grouping method. 
- Changed StationStream validate to label the stream as failed rather than raise an exception. 
- Added some additional validation to StationStream.
- Check that label does not have an underscore in it since we use that character to split to separate out the station and the label from the tag.
- Removed "test_raw" because we are going to remove the special handling of raw data and so this test will lose its relevance (and it is currently causing an error).