### PR TITLE
Fetchfix

### DIFF
--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -41,6 +41,36 @@ fetchers:
         # seconds after arrival time
         time_after : 420 
         channels : ["HN[ZNE]"] # only get strong motion stations
+        
+        network : "*"
+
+        # SY is a network for synthetic data
+        exclude_networks : 
+            - SY
+        
+        # uncomment this section to add stations that should be avoided
+        # exclude_stations:
+        #    - ABC*
+
+        # If True (default), MiniSEED files with gaps and/or overlaps will be rejected.
+        reject_channels_with_gaps : True
+
+        # The minimum length of the data as a fraction of the requested time frame. 
+        # After a channel has been downloaded it will be checked that its total 
+        # length is at least that fraction of the requested time span. 
+        # Will be rejected otherwise. Must be between 0.0 and 1.0.
+        minimum_length : 0.1
+
+        # Only download data that has accompanying StationXML metadata.
+        sanitize : True
+
+        # The minimum inter-station distance. 
+        # Data from any new station closer to any 
+        # existing station will not be downloaded. 
+        minimum_interstation_distance_in_m: 0.0
+
+
+        
 # -----------------------------------------------------------------------------
 # Options for readers
 read:
@@ -60,16 +90,6 @@ read:
 #    record_start       split              signal_end
 
 windows:
-
-    split:
-        # The noise-signal split can be estimated using a p-wave picker, or
-        # with an assumed arrival time for a phase velocity "vsplit". This
-        # velocity should exceed any reasonable p-wave velocities to ensure that
-        # none of the signal ends up in the noise window.
-
-        # Valid options for "method" are "p_arrival" and "velocity"
-        method: p_arrival
-        vsplit: 7.0
 
     signal_end:
         # The end of the signal can be set using a phase velocity.
@@ -403,6 +423,11 @@ pickers:
         threshDetect: 2.5
         threshDetect2: 2.5
         threshRestart: 1.5
+    
+    travel_time:
+        # this picker uses travel times using configured velocity model
+        model : iasp91
+
 
 
         

--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -40,7 +40,7 @@ fetchers:
         time_before : 30 
         # seconds after arrival time
         time_after : 420 
-        channels : ["HN[ZNE]"] # only get strong motion stations
+        channels : ["?H?", "?N?"] # only get strong motion and high-gain channels
         
         network : "*"
 

--- a/gmprocess/io/geonet/core.py
+++ b/gmprocess/io/geonet/core.py
@@ -317,10 +317,14 @@ def _read_header(hdr_data, station, name, component, data_format,
         year, month, day, hour, minute, seconds, microseconds)
 
     # figure out station coordinates
-    coordinates['latitude'] = -hdr_data[2, 0] + \
-        ((hdr_data[2, 1] + hdr_data[2, 2] / 60.0) / 60.0)
-    coordinates['longitude'] = hdr_data[2, 3] + \
-        ((hdr_data[2, 4] + hdr_data[2, 5] / 60.0) / 60.0)
+    latdg = hdr_data[2, 0]
+    latmn = hdr_data[2, 1]
+    latsc = hdr_data[2, 2]
+    coordinates['latitude'] = _dms_to_dd(latdg, latmn, latsc) * -1
+    londg = hdr_data[2, 3]
+    lonmn = hdr_data[2, 4]
+    lonsc = hdr_data[2, 5]
+    coordinates['longitude'] = _dms_to_dd(londg, lonmn, lonsc)
     coordinates['elevation'] = 0.0
 
     # get other standard metadata
@@ -373,3 +377,9 @@ def _get_channel(component):
                 comp_angle = 180 + angle
 
     return comp_angle
+
+
+def _dms_to_dd(degrees, minutes, seconds):
+    # convert degrees/minutes/seconds to decimal degrees
+    dd = degrees + minutes / 60 + seconds / 3600
+    return dd

--- a/gmprocess/io/utils.py
+++ b/gmprocess/io/utils.py
@@ -138,7 +138,13 @@ def _walk_and_unzip(directory):
     for dirpath, sub_dirs, files in os.walk(directory, topdown=False):
         for f in files:
             full_file = os.path.join(dirpath, f)
-            if zipfile.is_zipfile(full_file):
+            is_zip = False
+            try:
+                zipfile.ZipFile(full_file, 'r')
+                is_zip = True
+            except:
+                pass
+            if is_zip:
                 has_zips = True
                 base, ext = os.path.splitext(f)
                 with zipfile.ZipFile(full_file, 'r') as zip:

--- a/gmprocess/phase.py
+++ b/gmprocess/phase.py
@@ -91,11 +91,11 @@ def STALTA_Earle(data, datao, sps, STAW, STAW2, LTAW, hanning, threshold,
 
     for i in range(np.size(envelope) - lta_samples - 1):
         lta[i + lta_samples + 1] = np.sum(envelope[i:i + lta_samples])
-        sta[i + lta_samples + 1] = np.sum(envelope[i + lta_samples + 1:i
-                                                   + lta_samples + sta_samples + 1])
-        sta2[i + lta_samples + 1] = np.sum(envelope[i + lta_samples + 1:i
-                                                    + lta_samples + 1
-                                                    + sta_samples2])
+        sta[i + lta_samples + 1] = np.sum(envelope[i + lta_samples + 1:i +
+                                                   lta_samples + sta_samples + 1])
+        sta2[i + lta_samples + 1] = np.sum(envelope[i + lta_samples + 1:i +
+                                                    lta_samples + 1 +
+                                                    sta_samples2])
 
     lta = lta / float(lta_samples)
     sta = sta / float(sta_samples)
@@ -111,8 +111,8 @@ def STALTA_Earle(data, datao, sps, STAW, STAW2, LTAW, hanning, threshold,
     triggers_off = []
 
     for i in range(np.size(ratio) - 1):
-        if(trigger is False and ratio[i] >= threshold
-           and ratio2[i] >= threshold2 and ratio[i] > ratio[i + 1]):
+        if(trigger is False and ratio[i] >= threshold and
+           ratio2[i] >= threshold2 and ratio[i] > ratio[i + 1]):
             triggers_on.append(i)
             trigger = True
         elif(trigger is True and ratio[i] <= threshdrop):
@@ -319,6 +319,7 @@ def pick_travel(stream, origin, picker_config=None, config=None):
     lat = origin['lat']
     lon = origin['lon']
     depth = origin['depth']
+    etime = origin['time']
     slat = stream[0].stats.coordinates.latitude
     slon = stream[0].stats.coordinates.longitude
 
@@ -329,7 +330,7 @@ def pick_travel(stream, origin, picker_config=None, config=None):
     if not len(arrivals):
         return (-1, 0)
     arrival = arrivals[0]
-    minloc = arrival.time
+    minloc = arrival.time + (etime - stream[0].stats.starttime)
     mean_snr = calc_snr(stream, minloc)
     return (minloc, mean_snr)
 
@@ -554,8 +555,8 @@ def pphase_pick(trace, period=None, damping=0.6, nbins=None,
         trace_copy.detrend(type='linear')
 
     if peak_selection == 'True':
-        ind_peak = np.nonzero(np.abs(trace_copy.data)
-                              == np.max(np.abs(trace_copy.data)))
+        ind_peak = np.nonzero(np.abs(trace_copy.data) ==
+                              np.max(np.abs(trace_copy.data)))
         trace_copy.data = trace_copy.data[0:ind_peak[0][0]]
 
     # Construct a fixed-base viscously damped SDF oscillator

--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -110,13 +110,12 @@ def process_streams(streams, origin, config=None):
     for st in processed_streams:
         logging.info('Checking stream %s...' % st.get_id())
         # Estimate noise/signal split time
-        split_conf = window_conf['split']
         st = signal_split(
             st,
+            origin,
             event_time=event_time,
             event_lon=event_lon,
-            event_lat=event_lat,
-            **split_conf)
+            event_lat=event_lat)
 
         # Estimate end of signal
         end_conf = window_conf['signal_end']

--- a/gmprocess/report.py
+++ b/gmprocess/report.py
@@ -113,7 +113,7 @@ def build_report(sc, directory, origin, config=None):
         report += '\n'
         if st[0].hasParameter('signal_split'):
             pick_method = st[0].getParameter('signal_split')['picker_type']
-            report += 'Pick Method: %s\n\n' % pick_method
+            report += 'Pick Method: %s\n\n' % str_for_latex(pick_method)
         if not st.passed:
             for tr in st:
                 if tr.hasParameter('failure'):

--- a/gmprocess/stationtrace.py
+++ b/gmprocess/stationtrace.py
@@ -211,6 +211,11 @@ class StationTrace(Trace):
                     'bridge',
                     'dam',
                     'borehole',
+                    'hole',
+                    'crest',
+                    'toe',
+                    'foundation',
+                    'body',
                     'roof',
                     'floor']
         for ftype in non_free:

--- a/gmprocess/stationtrace.py
+++ b/gmprocess/stationtrace.py
@@ -636,9 +636,12 @@ def _stats_from_inventory(data, inventory, channelid):
     format_specific = {}
     if station.description is not None and station.description != 'None':
         jsonstr = station.description
-        big_dict = json.loads(jsonstr)
-        standard.update(big_dict['standard'])
-        format_specific = big_dict['format_specific']
+        try:
+            big_dict = json.loads(jsonstr)
+            standard.update(big_dict['standard'])
+            format_specific = big_dict['format_specific']
+        except json.decoder.JSONDecodeError:
+            format_specific['description'] = jsonstr
 
     response = None
     if channel.response is not None:

--- a/install.sh
+++ b/install.sh
@@ -124,11 +124,9 @@ package_list=(
     "lxml"
     "matplotlib"
     "numpy>=1.14"
-    "obspy"
     "openpyxl"
     "openquake.engine"
     "pandas"
-    "pyasdf"
     "pytest"
     "pytest-cov"
     "python>=3.6"
@@ -174,6 +172,10 @@ if [ $? -ne 0 ];then
     echo "Failed to upgrade pip, trying to continue..."
     exit 1
 fi
+
+# TEMPORARY FIX UNTIL obspy 1.1.1 is available via conda
+# on Mac
+pip install obspy==1.1.1 pyasdf
 
 # The presence of a __pycache__ folder in bin/ can cause the pip
 # install to fail... just to be safe, we'll delete it here.

--- a/tests/gmprocess/corner_frequencies_test.py
+++ b/tests/gmprocess/corner_frequencies_test.py
@@ -2,6 +2,7 @@
 import os
 
 import numpy as np
+from obspy.core.utcdatetime import UTCDateTime
 
 from gmprocess.streamcollection import StreamCollection
 from gmprocess.io.read import read_data
@@ -34,16 +35,16 @@ def test_corner_frequencies():
     for st in processed_streams:
         if st.passed:
             # Estimate noise/signal split time
-            split_conf = window_conf['split']
+            origin['time'] = UTCDateTime(origin['time'])
             event_time = origin['time']
             event_lon = origin['lon']
             event_lat = origin['lat']
             st = signal_split(
                 st,
+                origin,
                 event_time=event_time,
                 event_lon=event_lon,
-                event_lat=event_lat,
-                **split_conf)
+                event_lat=event_lat)
 
             # Estimate end of signal
             end_conf = window_conf['signal_end']
@@ -101,7 +102,7 @@ def test_corner_frequencies():
             hp.append(cfdict['highpass'])
     np.testing.assert_allclose(
         np.sort(hp),
-        [0.0030517578125, 0.013544549219578182, 0.02804439343254479, ],
+        [0.00751431, 0.01354455, 0.04250735],
         atol=1e-6
     )
 

--- a/tests/gmprocess/io/asdf/stream_workspace_test.py
+++ b/tests/gmprocess/io/asdf/stream_workspace_test.py
@@ -16,6 +16,7 @@ from gmprocess.streamcollection import StreamCollection
 
 from h5py.h5py_warnings import H5pyDeprecationWarning
 from yaml import YAMLLoadWarning
+from obspy.core.utcdatetime import UTCDateTime
 
 import numpy as np
 import pandas as pd
@@ -57,6 +58,7 @@ def compare_streams(instream, outstream):
 def test_workspace():
     eventid = 'us1000778i'
     datafiles, origin = read_data_dir('geonet', eventid, '*.V1A')
+    origin['time'] = UTCDateTime(origin['time'])
     event = get_event_object(origin)
     tdir = tempfile.mkdtemp()
     try:
@@ -202,12 +204,13 @@ def test_workspace():
 
             workspace.setStreamMetrics(usid, labels=['processed'])
             df = workspace.getMetricsTable(usid, labels=['processed'])
-            cmpdict = {
-                'GREATER_OF_TWO_HORIZONTALS': [26.904, 4.9814, 99.5713],
-                'HN1': [24.5162, 4.9814, 99.5713],
-                'HN2': [26.904, 4.0292, 86.7985],
-                'HNZ': [16.0978, 2.5057, 156.0942]
-            }
+
+            data = np.array([[26.8877, 24.5076, 26.8877, 16.0931],
+                             [4.9814, 4.9814, 4.0292, 2.5057],
+                             [99.6077, 99.6077, 86.7887, 151.8803]])
+            cmpdict = pd.DataFrame(data,
+                                   columns=['GREATER_OF_TWO_HORIZONTALS', 'HN1', 'HN2', 'HNZ'])
+
             cmpframe = pd.DataFrame(cmpdict)
             assert df['PGA'].equals(cmpframe)
 

--- a/tests/gmprocess/phase_test.py
+++ b/tests/gmprocess/phase_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from gmprocess.phase import (PowerPicker, pphase_pick, pick_ar,
-                             pick_kalkan, pick_power, pick_baer, pick_yeck)
+                             pick_kalkan, pick_power, pick_baer,
+                             pick_yeck, pick_travel)
 from gmprocess.io.read import read_data
 from gmprocess.io.test_utils import read_data_dir
 from gmprocess.exception import GMProcessException
@@ -103,13 +104,13 @@ def test_all_pickers():
         x = 1
     stations = df['Stream'].unique()
     cmpdict = {'TW.ECU.BN': 'kalkan',
-               'TW.ELD.BN': 'power',
-               'TW.EGF.BN': 'power',
-               'TW.EAS.BN': 'power',
-               'TW.EDH.BN': 'power',
-               'TK.4304.HN': 'kalkan',
-               'TK.0921.HN': 'baer',
-               'TK.5405.HN': 'power',
+               'TW.ELD.BN': 'ar',
+               'TW.EGF.BN': 'ar',
+               'TW.EAS.BN': 'ar',
+               'TW.EDH.BN': 'ar',
+               'TK.4304.HN': 'ar',
+               'TK.0921.HN': 'ar',
+               'TK.5405.HN': 'ar',
                'NZ.HSES.HN': 'baer',
                'NZ.WTMC.HN': 'baer',
                'NZ.THZ.HN': 'power'}
@@ -119,6 +120,21 @@ def test_all_pickers():
         maxrow = station_df[station_df['Mean_SNR'] == max_snr].iloc[0]
         method = maxrow['Method']
         assert cmpdict[station] == method
+
+
+def test_travel_time():
+    datafiles, origin = read_data_dir('geonet', 'us1000778i', '*.V1A')
+    streams = []
+    for datafile in datafiles:
+        streams += read_data(datafile)
+
+    cmps = {'NZ.HSES.HN': 42.118045132851641,
+            'NZ.WTMC.HN': 40.77244584723671,
+            'NZ.THZ.HN': 42.025007954412246}
+    for stream in streams:
+        origin['time'] = UTCDateTime(origin['time'])
+        minloc, mean_snr = pick_travel(stream, origin)
+        np.testing.assert_almost_equal(minloc, cmps[stream.get_id()])
 
 
 def get_streams():
@@ -138,3 +154,4 @@ if __name__ == '__main__':
     test_all_pickers()
     test_pphase_picker()
     test_p_pick()
+    test_travel_time()

--- a/tests/gmprocess/processing_test.py
+++ b/tests/gmprocess/processing_test.py
@@ -31,6 +31,7 @@ def test_process_streams():
     # Loma Prieta test station (nc216859)
 
     data_files, origin = read_data_dir('geonet', 'us1000778i', '*.V1A')
+    origin['time'] = UTCDateTime(origin['time'])
     streams = []
     for f in data_files:
         streams += read_data(f)
@@ -56,14 +57,14 @@ def test_process_streams():
 
     np.testing.assert_allclose(
         trace_maxes,
-        np.array([157.86557103, 240.42212954, 263.83768676]),
+        np.array([157.81975508, 240.33718094, 263.67804256]),
         rtol=1e-5
     )
 
 
 def test_free_field():
     data_files, origin = read_data_dir('kiknet', 'usp000hzq8')
-
+    origin['time'] = UTCDateTime(origin['time'])
     raw_streams = []
     for dfile in data_files:
         raw_streams += read_data(dfile)


### PR DESCRIPTION
 - default config now restricting channels to high-gain seismometers and accelerometers
 - fixed conversion of DMS to DD in Geonet reader
 - fixed bug in io/utils code where miniseed files are mistaken for zips.
 - implemented travel time p-arrival picker, removed p_arrival velocity method
 - handling inventory objects that actually have a description instead of the JSON string
   that we're packing in there
 - modified signal_split to prefer travel_time picker
 - pip installing obspy 1.1.1 and pyasdf until the former is installable via conda.
 - updates to a number of tests