### PR TITLE
Optimizations to plotting and signal split.

### DIFF
--- a/gmprocess/plot.py
+++ b/gmprocess/plot.py
@@ -562,7 +562,7 @@ def summary_plots(st, directory, origin):
 
     # Do not save files if running tests
     if 'CALLED_FROM_PYTEST' not in os.environ:
-        plt.tight_layout()
+        plt.subplots_adjust(hspace=0.35, wspace=0.35, top=0.97)
         file_name = os.path.join(
             directory,
             origin['id'] + '_' + stream_id + '.png')

--- a/gmprocess/windows.py
+++ b/gmprocess/windows.py
@@ -108,7 +108,7 @@ def signal_split(
                                 picker_config=picker_config,
                                 config=config)
     if loc > 0:
-        tsplit = st[0].times('utcdatetime')[0] + loc
+        tsplit = st[0].stats.starttime + loc
         preferred_picker = 'travel_time'
     else:
         pick_methods = ['ar', 'baer', 'power', 'kalkan']
@@ -143,12 +143,12 @@ def signal_split(
         max_snr = df['Mean_SNR'].max()
         if not np.isnan(max_snr):
             maxrow = df[df['Mean_SNR'] == max_snr].iloc[0]
-            tsplit = st[0].times('utcdatetime')[0] + maxrow['Pick_Time']
+            tsplit = st[0].stats.starttime + maxrow['Pick_Time']
             preferred_picker = maxrow['Method']
         else:
             tsplit = -1
 
-    if tsplit >= st[0].times('utcdatetime')[0]:
+    if tsplit >= st[0].stats.starttime:
         # Update trace params
         split_params = {
             'split_time': tsplit,


### PR DESCRIPTION
- Changed tr.stats.times('utcdatetime')[0] to tr.stats.starttime in signal split.
- Instead of using plt.tight_layout(), it's faster to use plt.subplots_adjust() in the summary plots.