### PR TITLE
Zero crossing update

### DIFF
--- a/gmprocess/zero_crossings.py
+++ b/gmprocess/zero_crossings.py
@@ -22,12 +22,23 @@ def check_zero_crossings(st, min_crossings=1.0):
     dur = (st[0].stats.npts - 1) * delta_t
 
     for tr in st:
-        zarray = np.multiply(tr.data[0:-2], tr.data[1:-1])
+        # Make a copy of the trace to trim it before counting crossings; we do
+        # not want to modify the trace but we only want to count the crossings
+        # within the trimmed window
+        trcopy = tr.copy()
+
+        etime = tr.getParameter('signal_end')['end_time']
+        split_time = tr.getParameter('signal_split')['split_time']
+
+        trcopy.trim(starttime=split_time, endtime=etime)
+
+        zarray = np.multiply(trcopy.data[0:-1], trcopy.data[1:])
         zindices = [i for (i, z) in enumerate(zarray) if z < 0]
         zero_count_tr = len(zindices)
 
         z_rate = zero_count_tr/dur
 
+        # Put results back into the original trace, not the copy
         tr.setParameter('ZeroCrossingRate',
                         {'crossing_rate': z_rate})
 


### PR DESCRIPTION
- Modify zero crossings to include last datapoint (does not have practical importance but it is cleaner)
- Add trim step prior to zero crossing calculation (though it doesn't actually preserve the trim)

Closes #265
