### PR TITLE
Fix theme specification (remote_theme for open-source theme).

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-theme: just-the-docs
+remote_theme: pmarsceill/just-the-docs
 title: Ground-Motion Processing Software
 baseurl: /groundmotion-processing
 #search_enabled: true


### PR DESCRIPTION
Use `remote_theme` instead of `theme` in `_config.yml` when using an open source Jekyll theme instead of an official GitHub pages theme.