### PR TITLE
Handle case where no traces are handed to streamcollection

### DIFF
--- a/gmprocess/streamcollection.py
+++ b/gmprocess/streamcollection.py
@@ -93,10 +93,11 @@ class StreamCollection(object):
 
         self.streams = newstreams
         if handle_duplicates:
-            self.__handle_duplicates(
-                max_dist_tolerance,
-                process_level_preference,
-                format_preference)
+            if len(self.streams):
+                self.__handle_duplicates(
+                    max_dist_tolerance,
+                    process_level_preference,
+                    format_preference)
         self.__group_by_net_sta_inst()
         self.validate()
 


### PR DESCRIPTION
It is possible that automated queries could result handing off an empty list of streams to streamcollection and it just needed a slight tweak so that it doesn't error out in this case. 