### PR TITLE
Fix issues with tags and labels

### DIFF
--- a/gmprocess/stationstream.py
+++ b/gmprocess/stationstream.py
@@ -320,7 +320,8 @@ class StationStream(Stream):
 
     def getInventory(self):
         """
-        Extract an ObsPy inventory object from a Stream read in by gmprocess tools.
+        Extract an ObsPy inventory object from a Stream read in by gmprocess
+        tools.
         """
         networks = [trace.stats.network for trace in self]
         if len(set(networks)) > 1:


### PR DESCRIPTION
- Change `workspace.getLabels` to get labels from waveforms rather than provenance. The error @jrekoske-usgs  was getting was because raw data does not have a provenance document and so the unprocessed record labels were not getting discovered
- Fixed duplicate eventid in provenance document path
- Fixed some tests to use pytest.raises to check for whether or not functions appropriately raise exceptions

Closes #283
Closes #296
