### PR TITLE
 Sorting IMTs, dmg/fdsn updates, and fixing stream workspace exceptions.

### DIFF
--- a/gmprocess/io/dmg/core.py
+++ b/gmprocess/io/dmg/core.py
@@ -45,7 +45,7 @@ DATE_PATTERNS = [
     '[0-9]{1}-[0-9]{1}-[0-9]{2}',
 ]
 
-TIME_MATCH = '[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{1}'
+TIME_MATCH = '[0-9]{2}:[0-9]{2}:..\.[0-9]{1}'
 
 code_file = pkg_resources.resource_filename('gmprocess', 'data/fdsn_codes.csv')
 
@@ -492,7 +492,8 @@ def _get_header_info_v1(int_data, flt_data, lines, level, location=''):
     latitude, longitude = _get_coords(latitude_str, longitude_str)
     coordinates['latitude'] = latitude
     coordinates['longitude'] = longitude
-    coordinates['elevation'] = np.nan
+    logging.warn('Setting elevation to 0.0')
+    coordinates['elevation'] = 0.0
 
     # Standard metadata
     standard['units_type'] = get_units_type(hdr['channel'])

--- a/gmprocess/io/fdsn/core.py
+++ b/gmprocess/io/fdsn/core.py
@@ -12,6 +12,7 @@ from obspy import read_inventory
 # local imports
 from gmprocess.stationtrace import StationTrace
 from gmprocess.stationstream import StationStream
+from gmprocess.io.seedname import get_channel_name, is_channel_north
 
 IGNORE_FORMATS = ['KNET']
 
@@ -123,6 +124,17 @@ def read_fdsn(filename):
                              header=ttrace.stats,
                              inventory=inventory)
         location = ttrace.stats.location
+
+        trace.stats.channel = get_channel_name(
+            trace.stats.sampling_rate,
+            trace.stats.channel[1] == 'N',
+            inventory.get_orientation(trace.id)['dip'] in [90, -90] or
+            trace.stats.channel[2] == 'Z',
+            is_channel_north(inventory.get_orientation(trace.id)['azimuth']))
+
+        if trace.stats.location == '':
+            trace.stats.location = '--'
+
         network = ttrace.stats.network
         if network in LOCATION_CODES:
             codes = LOCATION_CODES[network]

--- a/gmprocess/stationstream.py
+++ b/gmprocess/stationstream.py
@@ -441,7 +441,6 @@ def _channel_from_stats(stats):
 
     comments = Comment(stats.standard.comments)
     logging.debug('channel: %s' % stats.channel)
-    print(stats)
     channel = Channel(stats.channel,
                       stats.location,
                       stats.coordinates['latitude'],

--- a/gmprocess/stationstream.py
+++ b/gmprocess/stationstream.py
@@ -55,7 +55,7 @@ class StationStream(Stream):
             ets = [e.timestamp for e in ends]
 
             # Do we need to try to fix the start/end times?
-            times_match = len(set(sts)) == 1 & len(set(ets)) == 1
+            times_match = len(set(sts)) == 1 and len(set(ets)) == 1
             if not times_match:
                 newstart = max(starts)
                 newend = min(ends)
@@ -109,7 +109,7 @@ class StationStream(Stream):
                     newend = min(ends)
                     new_duration = newend-newstart
                     new_npts = int(new_duration / new_delta + 1)
-                    success = len(set(sts)) == 1 & len(set(ets)) == 1
+                    success = len(set(sts)) == 1 and len(set(ets)) == 1
 
                     # If not, resample
                     if not success:
@@ -422,6 +422,9 @@ def _channel_from_stats(stats):
     else:
         azimuth = 0
 
+    if not (azimuth >= 0 and azimuth <= 360):
+        azimuth = 0
+
     response = None
     if 'response' in stats:
         response = stats['response']
@@ -438,6 +441,7 @@ def _channel_from_stats(stats):
 
     comments = Comment(stats.standard.comments)
     logging.debug('channel: %s' % stats.channel)
+    print(stats)
     channel = Channel(stats.channel,
                       stats.location,
                       stats.coordinates['latitude'],


### PR DESCRIPTION
- IMTs now sorted correctly in metrics tables. Closes #338 
- Adjusted dmg reader to be able to read some additional time formats. Elevation set to 0.0 instead of np.nan which causes problems.
- FDSN reader location and channel naming is now consistent with other readers
- Fixed StationStream problem that was trying to check the time windows of constituent traces (the problem was that '&' has higher operator precedence over '==', needed to change to 'and'). Also now checks that azimuth is in the range [0,360] to prevent obspy from raising exceptions.