### PR TITLE
Fix duplicates test

### DIFF
--- a/tests/gmprocess/streamcollection_test.py
+++ b/tests/gmprocess/streamcollection_test.py
@@ -162,6 +162,10 @@ def test_duplicates():
             tr.stats.standard.source_format = 'cosmos'
 
     # Check that we keep the CE network due to the bad starttime on ZZ
+    sczz = sc_bad.select(station='23837', network='ZZ')
+    for st in sczz:
+        for tr in st:
+            tr.stats.starttime = UTCDateTime(0)
     sc = StreamCollection(streams=sc_bad.streams, handle_duplicates=True)
     assert sc.select(station='23837')[0][0].stats.network == 'CE'
 


### PR DESCRIPTION
Fix test of how duplicates are handled. The test behavior presumably changed when @jrekoske-usgs fixed the DMG reader to correctly read in the time in a recent pull request. It is not clear why the tests didn't fail previously. 