### PR TITLE
Filtering updates

### DIFF
--- a/docs/_data/navbar.yml
+++ b/docs/_data/navbar.yml
@@ -34,6 +34,8 @@ toc:
           url: /processing-steps/waveform-processing/phase-pickers.html
         - page: Baseline correction
           url: /processing-steps/waveform-processing/baseline-correction.html
+        - page: Filtering
+          url: /processing-steps/waveform-processing/filtering.html
       - page: Waveform metrics
         url: /processing-steps/waveform-metrics.html
       - page: Station metrics

--- a/docs/processing-steps/waveform-processing/filtering.md
+++ b/docs/processing-steps/waveform-processing/filtering.md
@@ -1,0 +1,27 @@
+# Filtering
+
+Filtering is broken down into a series of processing steps.
+
+
+## get_corner_frequencies
+
+The first step is to select the highpass and lowpass corner frequencies, as
+configured in the `get_corner_frequencies` step. There are two suppored
+methods: `constant` and `snr`. Each method has additional parameters that
+are set via their respective subsections. 
+
+
+The `snr` method requires an accurate estimate of the signal-to-noise, which
+is not always possible. This is why we provide the `constant` method, where
+the highpass and lowpass corners are manually selected and constant for all
+records.
+
+The `snr` method selects the highpass and lowpass corner frequencies such
+that the SNR criteria specified in the `compute_snr` section are satisfied
+for the resulting passband. In other words, the SNR for the frequencies in
+the passband are guaranteed to exceed the `threshold` specified under
+`compute_snr/check/threshold`. The corner frequencies are determined
+independently for each channel if `same_horiz` is set to False; otherwise
+the horizontal channels are forced to have the same corner frequencies,
+where the high of the highpass corners and the lower of the lowpass corners
+of the two channels are selected. 

--- a/docs/processing-steps/waveform-processing/initial-qc.md
+++ b/docs/processing-steps/waveform-processing/initial-qc.md
@@ -15,7 +15,7 @@ This information will be reviewable in the processing report that is
 generated at the end, or through inspection of the output data.
 
 
-## `check_free_field`
+## check_free_field
 
 The file readers to their best to determine whether or not a station is
 placed in a free field location or not. If the `reject_non_free_field`
@@ -23,7 +23,7 @@ option is set to True, then non free field stations will be marked as
 "failed."
 
 
-## `check_max_amplitude`
+## check_max_amplitude
 
 This is a very simple way to screen out clipped records, and is only
 applicable for non-strong-motion instruments. Priort to applying the
@@ -35,28 +35,28 @@ We have also encountered problematic data where the count never exceeds
 a reasonable minimum. So we also check that the maximum count exceeds
 the specified `min` value.
 
-## `max_traces`
+## max_traces
 
 Reliably handling instrumental arrays is not possible in our automated
 code, largely because the location code is not used in a systematic
 manner. Thus, this check marks any instrument that has more than `n_max`
 channels as "failed".
 
-## `min_sample_rate`
+## min_sample_rate
 
 For many applications, a minimum sample rate may be required. While this
 is slightly redundant with the instrumental codes that can be set
 querying the data, this is an extra check to ensure a minimum sample
 rate.
 
-## `check_zero_crossings`
+## check_zero_crossings
 
 This option allows you to require a minimum number of zero crossings per
 second within the signal window. This is intended to screen out instrumental
 failures, in particular instrumental resets, but can sometimes result
 in incorrectly screening out good records.
 
-## `check_sta_lta`
+## check_sta_lta
 
 This check the STA-to-LTA ratio (STA is "short term average" and LTA is
 "long term average"). The ratio is computed for record the full recond
@@ -69,14 +69,14 @@ records for which no pre-event noise is available. However, we have
 found that it often results in the rejection of data that would
 otherwise be considered acceptable.
 
-## `compute_snr`
+## compute_snr
 
 This processing step checks the signa-to-noise ratio (SNR), requiring that
 the minimum SNR exceeds the selected `threshold` between `min_freq` and
 `max_freq` where the Fourier spectra of the signal and noise are smoothed
 using the Konno-Omachi method with the selected `bandwidth` parameter.
 
-## `NNet_QA:`
+## NNet_QA:
 
 This is the application of the automated quality screening neural network
 model by Bellagamba et al. ([2019](https://doi.org/10.1193/122118EQS292M)). 

--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -490,6 +490,24 @@ def get_corner_frequencies(st, method='constant', constant=None, snr=None):
         st = corner_frequencies.constant(st, **constant)
     elif method == 'snr':
         st = corner_frequencies.snr(st, **snr)
+        if snr['same_horiz']:
+            lps = [tr.getParameter('corner_frequencies')['lowpass'] for tr in st]
+            hps = [tr.getParameter('corner_frequencies')['highpass'] for tr in st]
+            chs = [tr.stats.channel for tr in st]
+            hlps = []
+            hhps = []
+            for i in range(len(chs)):
+                if "z" not in chs[i].lower():
+                    hlps.append(lps[i])
+                    hhps.append(hps[i])
+            llp = np.max(hlps)
+            hhp = np.max(hhps)
+            for i in range(len(chs)):
+                if "z" not in chs[i].lower():
+                    cfdict = st[i].getParameter('corner_frequencies')
+                    cfdict['lowpass'] = llp
+                    cfdict['highpass'] = hhp
+                    st[i].setParameter('corner_frequencies', cfdict)
     else:
         raise ValueError("Corner frequency 'method' must be either "
                          "'constant' or 'snr'.")


### PR DESCRIPTION
- At some point we broke the `same_horiz` option for `get_corner_frequencies` and we didn't have good enough tests to realize
- This un-breaks that option and improves the tests
- Some small updates to docs on filtering; trying to explain the filtering algorithm is how I discovered the problem with the `same_horiz` option