### PR TITLE
Multiple event directory, fdsn reader, and nnet checks

### DIFF
--- a/bin/gmprocess
+++ b/bin/gmprocess
@@ -262,7 +262,6 @@ def main(args):
         config = get_config()
 
     outdir = args.outdir
-
     eventids = args.eventids
     textfile = args.textfile
     eventinfo = args.eventinfo
@@ -319,9 +318,12 @@ def main(args):
                     logfile = os.path.join(outdir, logfmt % os.getpid())
                     for eventid in chunk:
                         event = eventdict[eventid]
-                        workname = process_event(outdir, event, pcommands,
-                                                 config, input_directory, process_tag,
-                                                 logfile, files_created, args.format)
+                        if len(events) > 1 and input_directory is not None:
+                            input_directory = os.path.join(
+                                input_directory, event.id)
+                        workname = process_event(
+                            outdir, event, pcommands, config, input_directory,
+                            process_tag, logfile, files_created, args.format)
                         workspace_files.append(workname)
                     os._exit(0)
                 else:

--- a/gmprocess/io/fdsn/core.py
+++ b/gmprocess/io/fdsn/core.py
@@ -66,7 +66,7 @@ def _get_station_file(filename, stream):
     filebase, fname = os.path.split(filename)
     network = stream[0].stats.network
     station = stream[0].stats.station
-    pattern = '*%s.%s*.xml' % (network, station)
+    pattern = '%s.%s.xml' % (network, station)
     xmlfiles = glob.glob(os.path.join(filebase, pattern))
     if len(xmlfiles) != 1:
         return 'None'

--- a/gmprocess/nn_quality_assurance.py
+++ b/gmprocess/nn_quality_assurance.py
@@ -861,8 +861,21 @@ def NNet_QA(st, acceptance_threshold, model_name):
 
     if all_zeros:
         for tr in st:
-            tr.fail('The data for trace %s contains all zeros, so the '
-                    'NNet_QA is not able to be performed.')
+            tr.fail('The data contains all zeros, so the '
+                    'NNet_QA check is not able to be performed.')
+        return st
+
+    # Check that we have the required trace parameters
+    have_params = True
+    for tr in st:
+        if not {'signal_spectrum', 'noise_spectrum', 'snr'}.issubset(
+          set(tr.getParameterKeys())):
+            have_params = False
+
+    if not have_params:
+        for tr in st:
+            tr.fail('One or more traces in the stream does have the required '
+                    'trace parameters to perform the NNet_QA check.')
         return st
 
     # Create the path to the NN folder based on model name

--- a/tests/gmprocess/corner_frequencies_test.py
+++ b/tests/gmprocess/corner_frequencies_test.py
@@ -102,7 +102,7 @@ def test_corner_frequencies():
         atol=1e-6
     )
 
-    st = processed_streams[0]
+    st = processed_streams.select(station='HSES')[0]
     lps = [tr.getParameter('corner_frequencies')['lowpass'] for tr in st]
     hps = [tr.getParameter('corner_frequencies')['highpass'] for tr in st]
     np.testing.assert_allclose(
@@ -140,7 +140,7 @@ def test_corner_frequencies():
         atol=1e-6
     )
 
-    st = processed_streams[0]
+    st = processed_streams.select(station='HSES')[0]
     lps = [tr.getParameter('corner_frequencies')['lowpass'] for tr in st]
     hps = [tr.getParameter('corner_frequencies')['highpass'] for tr in st]
     np.testing.assert_allclose(


### PR DESCRIPTION
- gmprocess can now handle being passed a directory that contains a subdirectory for each event
- Adjusted FDSN reader to only accept StationXML files with name formatted as NET.STA.xml. This is a just temporary fix to proceed with processing, as the wildcard matching was causing problems for stations such as AV.ILW and AV.ILSW. This method works with all the files we create internally, the only problems could come up if someone tries to read StationXML files they created elsewhere. See #292. 
- Some additional checks before running the nnet.