### PR TITLE
Fixing problem in corner frequencies.

### DIFF
--- a/gmprocess/processing.py
+++ b/gmprocess/processing.py
@@ -490,7 +490,7 @@ def get_corner_frequencies(st, method='constant', constant=None, snr=None):
         st = corner_frequencies.constant(st, **constant)
     elif method == 'snr':
         st = corner_frequencies.snr(st, **snr)
-        if snr['same_horiz']:
+        if snr['same_horiz'] and st.passed:
             lps = [tr.getParameter('corner_frequencies')['lowpass'] for tr in st]
             hps = [tr.getParameter('corner_frequencies')['highpass'] for tr in st]
             chs = [tr.stats.channel for tr in st]


### PR DESCRIPTION
Makes sure that streams pass before enforcing the same corner frequencies across the horizontals. This makes sure that if corner_frequencies.snr fails, then we won't get an error trying to access the corner frequencies.