### PR TITLE
Fix banner padding and format of headings in documentation

### DIFF
--- a/docs/_sass/layout.scss
+++ b/docs/_sass/layout.scss
@@ -20,12 +20,12 @@
     position: fixed;
     top: 0;
     left: 0;
-    height: 2.5rem;
+    height: 3.2rem;
     width: 100%;
     background-color: #006F41;
     img {
 	height: 100%;
-	padding: 0.2rem;
+	padding: 0.5rem;
 	vertical-align: middle;
     }
     span {

--- a/docs/_sass/typography.scss
+++ b/docs/_sass/typography.scss
@@ -6,25 +6,25 @@
 h1,
 .text-alpha {
   @include fs-8;
-  font-weight: 300;
+  font-weight: 500;
 }
 
 h2,
 .text-beta {
   @include fs-6;
+  font-weight: 700;
 }
 
 h3,
 .text-gamma {
   @include fs-5;
+  font-weight: 700;
 }
 
 h4,
 .text-delta {
-  @include fs-2;
-  font-weight: 300;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+  @include fs-4;
+  font-weight: 700;
 }
 
 h5,


### PR DESCRIPTION
* Increase banner size and padding around USGS logo.
* Improve style of headings (all bold except h1; gradually decrease font size).