### PR TITLE
Fix addition of gmconvert section in navigation bar in docs

### DIFF
--- a/docs/_data/navbar.yml
+++ b/docs/_data/navbar.yml
@@ -54,9 +54,10 @@ toc:
         url: /gmprocess/reports.html
       - page: Exporting data
         url: /gmprocess/exporting.html
-  - title: Comverting data
+  - title: Converting data
+    subitems:
       - page: The gmconvert command
-        url: converting.html
+        url: /converting.html
   - title: Python scripting
     subitems:
       - page: Data structures


### PR DESCRIPTION
Fix navbar yaml file for addition of gmconvert section (missing subitems heading).
Fix some typo.
Fix link to converting.md.