### PR TITLE
Fix line spacing (eliminate overlap with code bg) and darken bg for code.

### DIFF
--- a/docs/_sass/code.scss
+++ b/docs/_sass/code.scss
@@ -4,7 +4,7 @@
 // stylelint-disable selector-no-qualifying-type, declaration-block-semicolon-newline-after,declaration-block-single-line-max-declarations, selector-no-type, selector-max-type
 
 code {
-  padding: 0.2em 0.15em;
+  padding: 0.1em 0.1em;
   font-weight: 400;
   background-color: $code-background-color;
   border: $border $border-color;
@@ -12,7 +12,7 @@ code {
 }
 
 pre.highlight {
-  padding: $sp-3;
+  padding: $sp-1;
   margin-bottom: 0;
   -webkit-overflow-scrolling: touch;
   background-color: $code-background-color;

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -5,7 +5,7 @@
 // $body-font-family: -apple-system, BlinkMacSystemFont, "helvetica neue", helvetica, roboto, noto, "segoe ui", arial, sans-serif;
 // $mono-font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
 $root-font-size: 12px;         // Base font-size for rems
-$body-line-height: 1.2;
+// $body-line-height: 1.4;
 // $body-heading-line-height: 1.15;
 //
 // //

--- a/docs/_sass/support/_variables.scss
+++ b/docs/_sass/support/_variables.scss
@@ -52,7 +52,7 @@ $red-300: #dd2e2e !default;
 
 $body-background-color: $white !default;
 $sidebar-color: $grey-lt-000 !default;
-$code-background-color: $grey-lt-000 !default;
+$code-background-color: $grey-lt-100 !default;
 
 $body-text-color: $grey-dk-100 !default;
 $body-heading-color: $grey-dk-300 !default;


### PR DESCRIPTION
Reduce the size of the box around inline code blocks and adjusted the line spacing to eliminate overlap between boxes and adjacent lines. 

Use a slightly darker background for code so it is more visible.