### PR TITLE
Fixing hypocentral distance calculation bug

### DIFF
--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -493,8 +493,8 @@ class StreamWorkspace(object):
             slon = stream[0].stats.coordinates.longitude
             sdep = stream[0].stats.coordinates.elevation
             epidist_m, _, _ = gps2dist_azimuth(elat, elon, slat, slon)
-            hypocentral_distance = distance(elat, elon, -sdep / M_PER_KM,
-                                            slat, slon, edepth)
+            hypocentral_distance = distance(elon, elat, edepth,
+                                            slon, slat, -sdep / M_PER_KM)
             xmlfmt = '''<station_metrics>
             <hypocentral_distance units="km">%.1f</hypocentral_distance>
             <epicentral_distance units="km">%.1f</epicentral_distance>

--- a/gmprocess/metrics/station_summary.py
+++ b/gmprocess/metrics/station_summary.py
@@ -415,9 +415,9 @@ class StationSummary(object):
             self._epicentral_distance = dist / M_PER_KM
             if event.depth is not None:
                 self._hypocentral_distance = distance(
-                    lat, lon, -elev / M_PER_KM,
-                    event.latitude,
+                    lon, lat, -elev / M_PER_KM,
                     event.longitude,
+                    event.latitude,
                     event.depth / M_PER_KM
                 )
 


### PR DESCRIPTION
Hypocentral distance calculations should be fixed. The lat sand lons needed to be switched in the function call to openquake.hazardlib.geo.geodetic.distance().