### PR TITLE
Workspace close, noise/signal detrending, and duplicate checking

### DIFF
--- a/bin/gmprocess
+++ b/bin/gmprocess
@@ -237,7 +237,7 @@ def process_event(outdir, event, pcommands,
     # since we don't know how many events users will be processing,
     # let's guard against memory issues by clearing out the big data
     # structures
-    del workspace
+    workspace.close()
 
     logging.info('Finishing event %s' % event.id)
 
@@ -424,7 +424,7 @@ def main(args):
                     if imc in timc_tables:
                         timc_table = timc_tables[imc]
                         imc_tables[imc] = pd.concat([imc_table, timc_table])
-            del workspace
+            workspace.close()
 
         if args.format == 'csv':
             eventfile = os.path.join(outdir, 'events.csv')

--- a/gmprocess/io/asdf/core.py
+++ b/gmprocess/io/asdf/core.py
@@ -51,7 +51,7 @@ def read_asdf(filename, eventid=None, stations=None, label=None):
                                        labels=labels)
         allstreams += streams
 
-    del workspace
+    workspace.close()
     return allstreams
 
 
@@ -70,4 +70,4 @@ def write_asdf(filename, streams, event, label=None):
     """
     workspace = StreamWorkspace(filename)
     workspace.addStreams(event, streams, label=label)
-    del workspace
+    workspace.close()

--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -95,6 +95,12 @@ class StreamWorkspace(object):
             raise IOError('File %s does not exist.' % filename)
         return cls(filename)
 
+    def close(self):
+        """Close the workspace.
+
+        """
+        del self.dataset
+
     def __repr__(self):
         """Provide summary string representation of the file.
 

--- a/gmprocess/snr.py
+++ b/gmprocess/snr.py
@@ -20,8 +20,8 @@ def compute_snr_trace(tr, bandwidth, check=None):
         if isinstance(split_prov, list):
             split_prov = split_prov[0]
         split_time = split_prov['split_time']
-        noise = tr.copy().trim(endtime=split_time)
-        signal = tr.copy().trim(starttime=split_time)
+        noise = tr.copy().trim(endtime=split_time).detrend('demean')
+        signal = tr.copy().trim(starttime=split_time).detrend('demean')
 
         # Taper both windows
         noise.taper(max_percentage=TAPER_WIDTH,

--- a/gmprocess/snr.py
+++ b/gmprocess/snr.py
@@ -20,8 +20,11 @@ def compute_snr_trace(tr, bandwidth, check=None):
         if isinstance(split_prov, list):
             split_prov = split_prov[0]
         split_time = split_prov['split_time']
-        noise = tr.copy().trim(endtime=split_time).detrend('demean')
-        signal = tr.copy().trim(starttime=split_time).detrend('demean')
+        noise = tr.copy().trim(endtime=split_time)
+        signal = tr.copy().trim(starttime=split_time)
+
+        noise.detrend('demean')
+        signal.detrend('demean')
 
         # Taper both windows
         noise.taper(max_percentage=TAPER_WIDTH,

--- a/gmprocess/streamcollection.py
+++ b/gmprocess/streamcollection.py
@@ -711,8 +711,17 @@ def are_duplicates(tr1, tr2, max_dist_tolerance):
         bool. True if traces are duplicates, False otherwise.
     """
 
+    orientation_codes = set()
+    for tr in [tr1, tr2]:
+        if tr.stats.channel[2] in ['1', 'N']:
+            orientation_codes.add('1')
+        elif tr.stats.channel[2] in ['2', 'E']:
+            orientation_codes.add('2')
+        else:
+            orientation_codes.add('Z')
+
     # First, check if the ids match (net.sta.loc.cha)
-    if tr1.id == tr2.id:
+    if (tr1.id[:-1] == tr2.id[:-1] and len(orientation_codes) == 1):
         return True
     # If not matching IDs, check the station, instrument code, and distance
     else:
@@ -720,9 +729,10 @@ def are_duplicates(tr1, tr2, max_dist_tolerance):
             tr1.stats.coordinates.latitude, tr1.stats.coordinates.longitude,
             tr2.stats.coordinates.latitude, tr2.stats.coordinates.longitude)[0]
         if (tr1.stats.station == tr2.stats.station
-            and tr1.stats.location == tr2.stats.location
-            and tr1.stats.channel == tr2.stats.channel
-                and distance < max_dist_tolerance):
+           and tr1.stats.location == tr2.stats.location
+           and tr1.stats.channel[:2] == tr2.stats.channel[:2]
+           and len(orientation_codes) == 1
+           and distance < max_dist_tolerance):
             return True
         else:
             return False

--- a/tests/gmprocess/corner_frequencies_test.py
+++ b/tests/gmprocess/corner_frequencies_test.py
@@ -98,7 +98,7 @@ def test_corner_frequencies():
             hp.append(cfdict['highpass'])
     np.testing.assert_allclose(
         np.sort(hp),
-        [0.00751431, 0.01354455, 0.04250735],
+        [0.003052, 0.003052, 0.010265],
         atol=1e-6
     )
 
@@ -112,7 +112,7 @@ def test_corner_frequencies():
     )
     np.testing.assert_allclose(
         np.sort(hps),
-        [0.00305176,  0.00751431,  0.02527502],
+        [0.003052,  0.010265,  0.025275],
         atol=1e-6
     )
 
@@ -136,7 +136,7 @@ def test_corner_frequencies():
 
     np.testing.assert_allclose(
         np.sort(hp),
-        [0.00751431, 0.01354455, 0.04882812],
+        [0.003052, 0.010265, 0.017872],
         atol=1e-6
     )
 
@@ -150,7 +150,7 @@ def test_corner_frequencies():
     )
     np.testing.assert_allclose(
         np.sort(hps),
-        [0.00751431,  0.00751431,  0.02527502],
+        [0.010265, 0.010265, 0.025275],
         atol=1e-6
     )
 

--- a/tests/gmprocess/io/asdf/stream_workspace_test.py
+++ b/tests/gmprocess/io/asdf/stream_workspace_test.py
@@ -75,7 +75,7 @@ def test_stream_params():
         outstreams = workspace.getStreams(event.id, labels=['stats'])
         cmpdict = outstreams[0].getStreamParam('stats')
         assert cmpdict == statsdict
-        del workspace
+        workspace.close()
     except Exception as e:
         raise(e)
     finally:
@@ -175,7 +175,7 @@ def test_workspace():
             if instream is None:
                 raise ValueError('Instream should not be none.')
             compare_streams(instream, outstream)
-            del workspace
+            workspace.close()
 
             # read in data from a second event and stash it in the workspace
             eventid = 'nz2018p115908'
@@ -275,7 +275,7 @@ def test_metrics():
         array2 = s1_df_out['Result'].as_matrix()
         np.testing.assert_almost_equal(array1, array2, decimal=4)
 
-        del workspace
+        workspace.close()
     except Exception as e:
         raise(e)
     finally:

--- a/tests/gmprocess/nn_quality_assurance_test.py
+++ b/tests/gmprocess/nn_quality_assurance_test.py
@@ -55,7 +55,7 @@ def test_nnet():
     allparams = tstream.getStreamParamKeys()
     nnet_dict = tstream.getStreamParam('nnet_qa')
     np.testing.assert_allclose(
-        nnet_dict['score_HQ'], 0.99321798811740059, rtol=1e-5)
+        nnet_dict['score_HQ'], 0.99321798811740059, rtol=1e-3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Reinstates the workspace close method to ensure that HDF5 files are properly flushed
- Noise and signal windows are each demeaned individually before computing SNR
- Fix for checking duplicates that have different channel names (e.g. HN1 vs HNN)
- Some tests needed updating because of the different SNR calculation, resulting in different corner frequencies