### PR TITLE
Handling updated event ids and magnitude type stuff.

### DIFF
--- a/bin/gmprocess
+++ b/bin/gmprocess
@@ -632,8 +632,8 @@ This program will allow the user to:
         'LAT LON DEP MAG'
     )
     group.add_argument(
-        '--eventinfo', help=help_event, type=str, nargs=6,
-        metavar=('ID', 'TIME', 'LAT', 'LON', 'DEPTH', 'MAG')
+        '--eventinfo', help=help_event, type=str, nargs=7,
+        metavar=('ID', 'TIME', 'LAT', 'LON', 'DEPTH', 'MAG', 'MAG_TYPE')
     )
 
     help_dir = format_helptext(

--- a/gmprocess/event.py
+++ b/gmprocess/event.py
@@ -1,3 +1,5 @@
+import logging
+
 # third party imports
 from obspy.core.event.origin import Origin
 from obspy.core.event.magnitude import Magnitude
@@ -181,6 +183,9 @@ def get_event_dict(eventid):
             - magnitude Origin magnitude.
     """
     dict_or_id = get_event_by_id(eventid)
+    if dict_or_id.id != eventid:
+        logging.warn('Event ID %s is no longer preferred. Updating with the '
+                     'preferred event ID: %s.' % (eventid, dict_or_id.id))
     event_dict = {'id': dict_or_id.id,
                   'time': UTCDateTime(dict_or_id.time),
                   'lat': dict_or_id.latitude,


### PR DESCRIPTION
- `get_event_dict` will now raise a warning if the ID of the returned event object is different than the input event ID.
- If the --directory argument is used in `gmprocess`, then the event folders in the directory will be renamed if the preferred event ID is different from the folder name. A warning is also issued when this happens. This is to prevent an error constructing paths when the preferred event ID might have been changed in ComCat. We also now ignore hidden files to prevent annoying warnings for folders like .DS_Store on Mac. Closes #421. 
- Fix for handling magnitude type when the --eventinfo argument is used
