### PR TITLE
README tables

### DIFF
--- a/bin/gmprocess
+++ b/bin/gmprocess
@@ -432,10 +432,10 @@ def main(args):
                     for eventid in workspace.getEventIds():
                         workspace.calcMetrics(
                             eventid, labels=labels, config=config)
-                    tevent_table, timc_tables = workspace.getTables(
+                    tevent_table, timc_tables, readmes = workspace.getTables(
                         labels[0], config=config)
                 else:
-                    tevent_table, timc_tables = workspace.getTables(
+                    tevent_table, timc_tables, readmes = workspace.getTables(
                         labels[0], config=None)
             if event_table is None:
                 event_table = tevent_table
@@ -466,6 +466,12 @@ def main(args):
                 imcfile = os.path.join(outdir, '%s.xlsx' % imc.lower())
                 imc_table.to_excel(imcfile, index=False)
                 append_file(files_created, 'IMC tables', imcfile)
+
+        for imc, readme_table in readmes.items():
+            readme_file = os.path.join(
+                outdir, '%s.csv' % (imc.lower() + '_README'))
+            readme_table.to_csv(readme_file, index=False)
+            append_file(files_created, 'README tables', readme_file)
 
         # make a regression plot of the most common imc/imt combination we
         # can find
@@ -698,8 +704,11 @@ This program will allow the user to:
 
     help_status = format_helptext(
         'Output failure information, either in short form ("short"), '
-        'long form ("long"), or network form ("net").'
-    )
+        'long form ("long"), or network form ("net"). '
+        'short: Two column table, where the columns are "failure reason" and '
+        '"number of records". net: Three column table where the columns are '
+        '"network", "number passed", and "number failed". long: Two column '
+        'table, where columns are "station ID" and "failure reason".')
     parser.add_argument(
         '--status', choices=['short', 'long', 'net'], dest='status',
         help=help_status

--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -649,6 +649,10 @@ class StreamWorkspace(object):
                      - HN2Highpass High pass filter corner frequency for
                        second horizontal channel
                      - ...desired IMTs (PGA, PGV, SA(0.3), etc.)
+                   - dictionary of README DataFrames, where keys are IMCs
+                     and values are DataFrames with columns:
+                     - Column header
+                     - Description
         '''
         event_table = pd.DataFrame(columns=EVENT_TABLE_COLUMNS)
         imc_tables = {}

--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -19,7 +19,7 @@ from openquake.hazardlib.geo.geodetic import distance
 from gmprocess.stationtrace import StationTrace, TIMEFMT_MS
 from gmprocess.stationstream import StationStream
 from gmprocess.streamcollection import StreamCollection
-from gmprocess.metrics.station_summary import StationSummary
+from gmprocess.metrics.station_summary import StationSummary, XML_UNITS
 from gmprocess.exception import GMProcessException
 from gmprocess.event import ScalarEvent
 
@@ -29,21 +29,53 @@ EVENT_TABLE_COLUMNS = ['id', 'time', 'latitude',
 NON_IMT_COLUMNS = ['ELEVATION', 'EPICENTRAL_DISTANCE',
                    'HYPOCENTRAL_DISTANCE', 'LAT', 'LON',
                    'NAME', 'NETID', 'SOURCE', 'STATION']
-FLATFILE_COLUMNS = ['EarthquakeId', 'EarthquakeTime', 'EarthquakeLatitude',
-                    'EarthquakeLongitude', 'EarthquakeDepth',
-                    'EarthquakeMagnitude', 'EarthquakeMagnitudeType',
-                    'Network', 'NetworkDescription',
-                    'StationCode', 'StationID',
-                    'StationDescription',
-                    'StationLatitude', 'StationLongitude',
-                    'StationElevation', 'SamplingRate',
-                    'EpicentralDistance', 'HypocentralDistance',
-                    'H1Lowpass', 'H1Highpass',
-                    'H2Lowpass', 'H2Highpass', 'SourceFile']
+
+# List of columns in the flatfile, along with their descriptions for the README
+FLATFILE_COLUMNS = {
+    'EarthquakeId': 'Event ID from Comcat',
+    'EarthquakeTime': 'Earthquake origin time (UTC)',
+    'EarthquakeLatitude': 'Earthquake latitude (decimal degrees)',
+    'EarthquakeLongitude': 'Earthquake longitude (decimal degrees)',
+    'EarthquakeDepth': 'Earthquake depth (km)',
+    'EarthquakeMagnitude': 'Earthquake magnitude',
+    'EarthquakeMagnitudeType': 'Earthquake magnitude type',
+    'Network': 'Network code',
+    'NetworkDescription': 'Data source network',
+    'StationCode': 'Station code',
+    'StationID': 'Concatenated network, station, and instrument codes',
+    'StationDescription': 'Station description',
+    'StationLatitude': 'Station latitude (decimal degrees)',
+    'StationLongitude': 'Station longitude (decimal degrees)',
+    'StationElevation': 'Station elevation (m)',
+    'SamplingRate': 'Record sampling rate (Hz)',
+    'EpicentralDistance': 'Epicentral distance (km)',
+    'HypocentralDistance': 'Hypocentral distance (km)',
+    'H1Lowpass': 'H1 channel lowpass frequency (Hz)',
+    'H1Highpass': 'H1 channel highpass frequency (Hz)',
+    'H2Lowpass': 'H2 channel lowpass frequency (Hz)',
+    'H2Highpass': 'H2 channel highpass frequency (Hz)',
+    'SourceFile': 'Source file'}
+
+FLATFILE_IMT_COLUMNS = {
+    'PGA': 'Peak ground acceleration (%s)'
+           % XML_UNITS['pga'],
+    'PGV': 'Peak ground velocity (%s)'
+           % XML_UNITS['pgv'],
+    'SA(X)': 'Pseudo-spectral acceleration (%s) at X seconds'
+           % XML_UNITS['sa'],
+    'FAS(X)': 'Fourier amplitude spectrum value (%s) at X seconds'
+           % XML_UNITS['fas'],
+    'DURATION': '5-95 percent significant duration (%s)'
+           % XML_UNITS['duration'],
+    'ARIAS': 'Arias intensity (%s)'
+           % XML_UNITS['arias']
+}
+
 
 M_PER_KM = 1000
 
 FORMAT_VERSION = '1.0'
+
 
 def format_netsta(stats):
     return '{st.network}.{st.station}'.format(st=stats)
@@ -620,6 +652,7 @@ class StreamWorkspace(object):
         '''
         event_table = pd.DataFrame(columns=EVENT_TABLE_COLUMNS)
         imc_tables = {}
+        readme_tables = {}
         for eventid in self.getEventIds():
             event = self.getEvent(eventid)
             edict = {
@@ -654,13 +687,37 @@ class StreamWorkspace(object):
 
                 for imc in imclist:
                     if imc not in imc_tables:
-                        cols = FLATFILE_COLUMNS + imtlist
+                        cols = list(FLATFILE_COLUMNS.keys()) + imtlist
                         imc_table = pd.DataFrame(columns=cols)
                         row = _get_table_row(stream, summary, event, imc)
                         if not len(row):
                             continue
                         imc_table = imc_table.append(row, ignore_index=True)
                         imc_tables[imc] = imc_table
+
+                        imtlist_readme = []
+                        for imt in imtlist:
+                            # Check if this an actual IMT/IMC combination that
+                            # we have
+                            if imt in summary.pgms[
+                                    summary.pgms['IMC'] == imc].dropna(
+                                        )['IMT'].values:
+                                imt = imt.upper()
+                                if imt.startswith('SA'):
+                                    imtlist_readme.append('SA(X)')
+                                elif imt.startswith('FAS'):
+                                    imtlist_readme.append('FAS(X)')
+                                else:
+                                    imtlist_readme.append(imt)
+                            imtlist_readme.sort()
+
+                        df_readme = pd.DataFrame.from_dict(
+                            {**FLATFILE_COLUMNS,
+                             **{imt: FLATFILE_IMT_COLUMNS[imt]
+                                for imt in imtlist_readme}}, orient='index')
+                        df_readme.reset_index(level=0, inplace=True)
+                        df_readme.columns = ['Column header', 'Description']
+                        readme_tables[imc] = df_readme
                     else:
                         imc_table = imc_tables[imc]
                         row = _get_table_row(stream, summary, event, imc)
@@ -676,7 +733,7 @@ class StreamWorkspace(object):
                     table.drop(columns=col, inplace=True)
             imc_tables[key] = table
 
-        return (event_table, imc_tables)
+        return (event_table, imc_tables, readme_tables)
 
     def getStreamMetrics(self, eventid, network, station, label):
         """Extract a StationSummary object from the ASDF file for a given input Stream.

--- a/gmprocess/plot.py
+++ b/gmprocess/plot.py
@@ -390,7 +390,10 @@ def plot_moveout(streams, epilat, epilon, orientation=None, max_dist=None,
             if code == '3':
                 orientation_codes[i] = 'Z'
         channel_counter = Counter(orientation_codes)
-        orientation = max(channel_counter, key=channel_counter.get)
+        if channel_counter:
+            orientation = max(channel_counter, key=channel_counter.get)
+        else:
+            return (fig, ax)
 
     valid_channels = []
     if orientation in ['N', '1']:

--- a/tests/gmprocess/io/asdf/stream_workspace_test.py
+++ b/tests/gmprocess/io/asdf/stream_workspace_test.py
@@ -229,11 +229,15 @@ def test_metrics2():
         workspace.addEvent(event)
         workspace.addStreams(event, processed_streams, label='processed')
         workspace.calcMetrics(event.id, labels=['processed'])
-        etable, imc_tables1 = workspace.getTables('processed')
-        etable2, imc_tables2 = workspace.getTables('processed', config=config)
+        etable, imc_tables1, readmes1 = workspace.getTables('processed')
+        etable2, imc_tables2, readmes2 = workspace.getTables(
+            'processed', config=config)
         assert 'ARITHMETIC_MEAN' not in imc_tables1
+        assert 'ARITHMETIC_MEAN' not in readmes1
         assert 'ARITHMETIC_MEAN' in imc_tables2
+        assert 'ARITHMETIC_MEAN' in readmes2
         assert 'ARIAS' in imc_tables2['ARITHMETIC_MEAN']
+        assert 'ARIAS' in readmes2['ARITHMETIC_MEAN']['Column header'].values
     except Exception as e:
         raise(e)
     finally:


### PR DESCRIPTION
- For each exported IMC table, we now also create a README table which describes all of the columns from the IMC table. The README tables are created using `workspace.getTables()`. Closes #445 
- Improving the help string for the `--status` argument to be more descriptive.