### PR TITLE
Stress drop parameters

### DIFF
--- a/bin/gmprocess
+++ b/bin/gmprocess
@@ -406,6 +406,7 @@ def main(args):
 
         event_table = None
         imc_tables = {}
+        df_fit_spectra = pd.DataFrame()
         for workspace_file in workspace_files:
             workspace = StreamWorkspace.open(workspace_file)
             labels = workspace.getLabels()
@@ -437,6 +438,9 @@ def main(args):
                 else:
                     tevent_table, timc_tables, readmes = workspace.getTables(
                         labels[0], config=None)
+                    df_fit_spectra = pd.concat((
+                        df_fit_spectra, workspace.getFitSpectraTable(
+                            eventid, labels[0])))
             if event_table is None:
                 event_table = tevent_table
             else:
@@ -472,6 +476,10 @@ def main(args):
                 outdir, '%s.csv' % (imc.lower() + '_README'))
             readme_table.to_csv(readme_file, index=False)
             append_file(files_created, 'README tables', readme_file)
+
+        spectra_file = os.path.join(outdir, 'fit_spectra_parameters.csv')
+        df_fit_spectra.to_csv(spectra_file, index=False)
+        append_file(files_created, 'Fit spectra table', spectra_file)
 
         # make a regression plot of the most common imc/imt combination we
         # can find

--- a/bin/gmprocess
+++ b/bin/gmprocess
@@ -438,9 +438,9 @@ def main(args):
                 else:
                     tevent_table, timc_tables, readmes = workspace.getTables(
                         labels[0], config=None)
-                    df_fit_spectra = pd.concat((
-                        df_fit_spectra, workspace.getFitSpectraTable(
-                            eventid, labels[0])))
+                    ev_fit_spec, fit_readme = workspace.getFitSpectraTable(
+                            eventid, labels[0])
+                    df_fit_spectra = pd.concat((df_fit_spectra, ev_fit_spec))
             if event_table is None:
                 event_table = tevent_table
             else:
@@ -480,6 +480,11 @@ def main(args):
         spectra_file = os.path.join(outdir, 'fit_spectra_parameters.csv')
         df_fit_spectra.to_csv(spectra_file, index=False)
         append_file(files_created, 'Fit spectra table', spectra_file)
+
+        fit_readme_file = os.path.join(
+            outdir, 'fit_spectra_parameters_README.csv')
+        fit_readme.to_csv(fit_readme_file, index=False)
+        append_file(files_created, 'README tables', fit_readme_file)
 
         # make a regression plot of the most common imc/imt combination we
         # can find

--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -71,6 +71,36 @@ FLATFILE_IMT_COLUMNS = {
            % XML_UNITS['arias']
 }
 
+# List of columns in the fit_spectra_parameters file, along README descriptions
+FIT_SPECTRA_COLUMNS = {
+    'EarthquakeId': 'Event ID from Comcat',
+    'EarthquakeTime': 'Earthquake origin time (UTC)',
+    'EarthquakeLatitude': 'Earthquake latitude (decimal degrees)',
+    'EarthquakeLongitude': 'Earthquake longitude (decimal degrees)',
+    'EarthquakeDepth': 'Earthquake depth (km)',
+    'EarthquakeMagnitude': 'Earthquake magnitude',
+    'EarthquakeMagnitudeType': 'Earthquake magnitude type',
+    'TraceID': 'NET.STA.LOC.CHA',
+    'StationLatitude': 'Station latitude (decimal degrees)',
+    'StationLongitude': 'Station longitude (decimal degrees)',
+    'StationElevation': 'Station elevation (m)',
+    'fmin': 'Record highpass filter frequency (Hz)',
+    'fmax': 'Record lowpass filter frequency (Hz)',
+    'epi_dist': 'Epicentral distance (km)',
+    'f0': 'Brune corner frequency (Hz)',
+    'kappa': 'Site diminution factor (sec)',
+    'magnitude': 'Magnitude from optimized moment',
+    'minimize_message':
+        'Output message from scipy.optimize.minimize',
+    'minimize_success':
+        'Boolean flag indicating if the optimizer exited successfully',
+    'moment': 'Moment fit (dyne-cm)',
+    'moment_lnsd': 'Natural log standard deviation of the moment fit',
+    'stress_drop': 'Stress drop fit (bars)',
+    'stress_drop_lnsd':
+        'Natural log standard deviation of the stress drop fit',
+}
+
 
 M_PER_KM = 1000
 
@@ -741,8 +771,10 @@ class StreamWorkspace(object):
 
     def getFitSpectraTable(self, eventid, label):
         """
-        Returns a pandas DataFrame containing the fit_spectra parameters for
-        each trace in the workspace matching eventid and label.
+        Returns a tuple of two pandas DataFrames. The first contains the
+        fit_spectra parameters for each trace in the workspace matching
+        eventid and label. The second is a README describing each column
+        in the first DataFrame.
 
         Args:
             eventid (str):
@@ -755,18 +787,39 @@ class StreamWorkspace(object):
                 A DataFrame containing the fit_spectra parameters on a trace-
                 by-trace basis.
         """
-        df = pd.DataFrame()
+        df = pd.DataFrame(columns=FIT_SPECTRA_COLUMNS.keys())
+        event = self.getEvent(eventid)
         streams = self.getStreams(eventid, labels=[label])
         for st in streams:
-            if st.passed:
-                for tr in st:
-                    if tr.hasParameter('fit_spectra'):
-                        fit_spectra_dict = tr.getParameter('fit_spectra')
-                        fit_spectra_dict['EarthquakeID'] = eventid
-                        fit_spectra_dict['TraceID'] = tr.id
-                        df = df.append(tr.getParameter('fit_spectra'),
-                                       ignore_index=True)
-        return df
+            if not st.passed:
+                continue
+            for tr in st:
+                if tr.hasParameter('fit_spectra'):
+                    fit_dict = tr.getParameter('fit_spectra')
+                    fit_dict['EarthquakeId'] = eventid
+                    fit_dict['EarthquakeTime'] = event.time
+                    fit_dict['EarthquakeLatitude'] = event.latitude
+                    fit_dict['EarthquakeLongitude'] = event.longitude
+                    fit_dict['EarthquakeDepth'] = event.depth_km
+                    fit_dict['EarthquakeMagnitude'] = event.magnitude
+                    fit_dict['EarthquakeMagnitudeType'] = event.magnitude_type
+                    fit_dict['TraceID'] = tr.id
+                    fit_dict['StationLatitude'] = tr.stats.coordinates.latitude
+                    fit_dict['StationLongitude'] = \
+                        tr.stats.coordinates.longitude
+                    fit_dict['StationElevation'] = \
+                        tr.stats.coordinates.elevation
+                    if tr.hasParameter('corner_frequencies'):
+                        freq_dict = tr.getParameter('corner_frequencies')
+                        fit_dict['fmin'] = freq_dict['highpass']
+                        fit_dict['fmax'] = freq_dict['lowpass']
+                    df = df.append(fit_dict, ignore_index=True)
+
+        readme = pd.DataFrame.from_dict(FIT_SPECTRA_COLUMNS, orient='index')
+        readme.reset_index(level=0, inplace=True)
+        readme.columns = ['Column header', 'Description']
+
+        return (df, readme)
 
     def getStreamMetrics(self, eventid, network, station, label):
         """Extract a StationSummary object from the ASDF file for a given input Stream.

--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -739,6 +739,35 @@ class StreamWorkspace(object):
 
         return (event_table, imc_tables, readme_tables)
 
+    def getFitSpectraTable(self, eventid, label):
+        """
+        Returns a pandas DataFrame containing the fit_spectra parameters for
+        each trace in the workspace matching eventid and label.
+
+        Args:
+            eventid (str):
+                Return parameters only for the given eventid.
+            label (str):
+                Return parameters only for the given label.
+
+        Returns:
+            pandas.DataFrame:
+                A DataFrame containing the fit_spectra parameters on a trace-
+                by-trace basis.
+        """
+        df = pd.DataFrame()
+        streams = self.getStreams(eventid, labels=[label])
+        for st in streams:
+            if st.passed:
+                for tr in st:
+                    if tr.hasParameter('fit_spectra'):
+                        fit_spectra_dict = tr.getParameter('fit_spectra')
+                        fit_spectra_dict['EarthquakeID'] = eventid
+                        fit_spectra_dict['TraceID'] = tr.id
+                        df = df.append(tr.getParameter('fit_spectra'),
+                                       ignore_index=True)
+        return df
+
     def getStreamMetrics(self, eventid, network, station, label):
         """Extract a StationSummary object from the ASDF file for a given input Stream.
 

--- a/gmprocess/spectrum.py
+++ b/gmprocess/spectrum.py
@@ -22,7 +22,7 @@ def fit_spectra(st, origin, kappa=0.035,
                 min_stress=0.1,
                 max_stress=10000):
     """
-    Fit spectra vaying stress_drop and kappa.
+    Fit spectra vaying stress_drop and moment.
 
     Args:
         st (StationStream):
@@ -165,7 +165,7 @@ def fit_spectra(st, origin, kappa=0.035,
                 'moment_lnsd': sd[0],
                 'magnitude': magnitude_fit,
                 'f0': f0_fit,
-                'minimize_mesage': result.message.decode(),
+                'minimize_message': result.message.decode(),
                 'minimize_success': result.success
             }
             tr.setParameter('fit_spectra', fit_spectra_dict)


### PR DESCRIPTION
- Adds a method to stream_workspace for retreiving a DataFrame of the fit_spectra parameters for all streams in the workspace. Also returns a README DataFrame.
- Using `gmprocess --export` will call this new method and save the fit_spectra parameters and README to the output directory.