### PR TITLE
Metrics speedup and optimization.

### DIFF
--- a/gmprocess/metrics/combination/combination.py
+++ b/gmprocess/metrics/combination/combination.py
@@ -35,7 +35,7 @@ class Combination(object):
                 # Group all of the max values from traces without
                 # Z in the channel name
                 if 'Z' not in trace.stats['channel'].upper():
-                    horizontal_channels += [trace.copy()]
+                    horizontal_channels += [trace]
             ## Test the horizontals
             if len(horizontal_channels) > 2:
                 raise PGMException('Combination: More than two horizontal channels.')

--- a/gmprocess/metrics/metrics_controller.py
+++ b/gmprocess/metrics/metrics_controller.py
@@ -165,7 +165,7 @@ class MetricsController(object):
         bandwidth = metrics['fas']['bandwidth']
         controller = cls(imts, imcs, timeseries, bandwidth=bandwidth,
                          damping=damping, event=event, smooth_type=smoothing)
-        
+
         return controller
 
     @property
@@ -282,7 +282,7 @@ class MetricsController(object):
                 period = float(period)
             if percentile is not None:
                 percentile = float(percentile)
-            tseries = self.timeseries.copy()
+
             # paths
             transform_path = 'gmprocess.metrics.transform.'
             rotation_path = 'gmprocess.metrics.rotation.'
@@ -295,7 +295,8 @@ class MetricsController(object):
                     transform_path + step_set['Transform1'])
                 t1_cls = self._get_subclass(inspect.getmembers(
                     t1_mod, inspect.isclass), 'Transform')
-                t1 = t1_cls(tseries, self.damping, period, self._times).result
+                t1 = t1_cls(self.timeseries, self.damping, period,
+                            self._times).result
 
                 # -------------------------------------------------------------
                 # Transform 2

--- a/gmprocess/metrics/reduction/arias.py
+++ b/gmprocess/metrics/reduction/arias.py
@@ -49,10 +49,13 @@ class Arias(Reduction):
             # Calculate Arias Intensity
             integrated_acc2 = integrate.cumtrapz(acc * acc, dx=dt)
             arias_intensity = integrated_acc2 * np.pi * GAL_TO_PCTG / 2
-            channel = trace.stats.channel
-            trace.stats.standard.units = 'veloc'
-            trace.stats.npts = len(arias_intensity)
-            arias_stream.append(StationTrace(arias_intensity, trace.stats))
+
+            # Create a copy of stats so we don't modify original data
+            stats = trace.stats.copy()
+            channel = stats.channel
+            stats.standard.units = 'vel'
+            stats.npts = len(arias_intensity)
+            arias_stream.append(StationTrace(arias_intensity, stats))
             arias_intensities[channel] = np.abs(np.max(arias_intensity))
         self.arias_stream = arias_stream
         return arias_intensities

--- a/gmprocess/metrics/rotation/rotation.py
+++ b/gmprocess/metrics/rotation/rotation.py
@@ -36,7 +36,7 @@ class Rotation(object):
             # Group all of the max values from traces without
             # Z in the channel name
             if 'Z' not in trace.stats['channel'].upper():
-                horizontal_channels += [trace.copy()]
+                horizontal_channels += [trace]
         # Test the horizontals
         if len(horizontal_channels) > 2:
             raise PGMException('Rotation: More than two horizontal channels.')

--- a/gmprocess/metrics/transform/differentiate.py
+++ b/gmprocess/metrics/transform/differentiate.py
@@ -30,7 +30,7 @@ class Differentiate(Transform):
         """
         stream = StationStream([])
         for trace in self.transform_data:
-            integrated_trace = trace.differentiate()
+            integrated_trace = trace.copy().differentiate()
             integrated_trace.stats['units'] = 'acc'
             strace = StationTrace(data=integrated_trace.data,
                     header=integrated_trace.stats)

--- a/gmprocess/metrics/transform/fft.py
+++ b/gmprocess/metrics/transform/fft.py
@@ -34,8 +34,16 @@ class FFT(Transform):
         sampling_rate = horizontals[0].stats.sampling_rate
         freqs = np.fft.rfftfreq(nfft, 1 / sampling_rate)
         ft_traces = [freqs]
+
+        # Check if we already have computed the FFT for this trace
         for trace in horizontals:
-            # the fft scales so the factor of 1/nfft is applied
-            spectra = abs(np.fft.rfft(trace.data, n=nfft)) / nfft
+            if trace.hasCached('fas_spectrum'):
+                spectra = trace.getCached('fas_spectrum')
+            else:
+                # the fft scales so the factor of 1/nfft is applied
+                spectra = abs(np.fft.rfft(trace.data, n=nfft)) / nfft
+                trace.setCached('fas_spectrum', spectra)
+
             ft_traces += [spectra]
+
         return ft_traces

--- a/gmprocess/metrics/transform/integrate.py
+++ b/gmprocess/metrics/transform/integrate.py
@@ -30,8 +30,8 @@ class Integrate(Transform):
         """
         stream = StationStream([])
         for trace in self.transform_data:
-            integrated_trace = trace.integrate()
-            integrated_trace.stats['units'] = 'veloc'
+            integrated_trace = trace.copy().integrate()
+            integrated_trace.stats['units'] = 'vel'
             strace = StationTrace(data=integrated_trace.data,
                     header=integrated_trace.stats)
             stream.append(strace)

--- a/gmprocess/metrics/transform/transform.py
+++ b/gmprocess/metrics/transform/transform.py
@@ -36,7 +36,7 @@ class Transform(object):
             # Group all of the max values from traces without
             # Z in the channel name
             if 'Z' not in trace.stats['channel'].upper():
-                horizontal_channels += [trace.copy()]
+                horizontal_channels += [trace]
         ## Test the horizontals
         if len(horizontal_channels) > 2:
             raise PGMException('Rotation: More than two horizontal channels.')


### PR DESCRIPTION
FFT transform for FAS calculations now checks if the spectra have already been computed, which speeds things up when looping over lots of periods. Closes #412 

This also speeds up metrics calculations by avoiding making copies of streams (which is expensive). Instead of always making copies, we only make copies now when the data is directly modified (such as integrate and differentiate methods).