### PR TITLE
Optimizing various things.

### DIFF
--- a/bin/gmprocess
+++ b/bin/gmprocess
@@ -78,7 +78,7 @@ def process_event(outdir, event, pcommands,
                   config, input_directory,
                   process_tag, logfile,
                   files_created, output_format,
-                  status):
+                  status, recompute_metrics):
 
     # setup logging to write to the input logfile
     argthing = namedtuple('args', ['debug', 'quiet'])
@@ -172,14 +172,90 @@ def process_event(outdir, event, pcommands,
             and len(rstreams)):
         logging.info('Processing raw streams for event %s...' % event.id)
         pstreams = process_streams(rstreams, event, config=config)
+
         with warnings.catch_warnings():
             warnings.simplefilter("ignore",
                                   category=H5pyDeprecationWarning)
             workspace.addStreams(event, pstreams, label=process_tag)
             workspace.calcMetrics(event.id,
                                   labels=[process_tag],
-                                  config=config)
+                                  config=config,
+                                  streams=pstreams,
+                                  stream_label=process_tag)
         processing_done = True
+
+    if 'export' in pcommands:
+        labels = workspace.getLabels()
+        if 'unprocessed' not in labels:
+            fmt = ('Workspace file "%s" appears to have no unprocessed '
+                   'data. Skipping.')
+            logging.info(fmt % workspace_file)
+        else:
+            labels.remove('unprocessed')
+            if not labels:
+                fmt = ('Workspace file "%s" appears to have no processed '
+                       'data. Skipping.')
+                logging.info(fmt % workspace_file)
+            else:
+                logging.info('Creating tables for event %s...', event.id)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore",
+                                          category=H5pyDeprecationWarning)
+                    if recompute_metrics:
+                        del workspace.dataset.auxiliary_data.WaveFormMetrics
+                        del workspace.dataset.auxiliary_data.StationMetrics
+                        workspace.calcMetrics(
+                            eventid, labels=labels, config=config)
+                    event_table, imc_tables, readmes = workspace.getTables(
+                        labels[0], config=None, streams=pstreams,
+                        stream_label=process_tag)
+                    ev_fit_spec, fit_readme = workspace.getFitSpectraTable(
+                        event.id, labels[0], pstreams)
+
+                # Set the precisions for the imc tables, event table, and
+                # fit_spectra table before writing
+                imc_tables_formatted = {}
+                for imc, imc_table in imc_tables.items():
+                    imc_tables_formatted[imc] = set_precisions(imc_table)
+                event_table_formatted = set_precisions(event_table)
+                df_fit_spectra_formatted = set_precisions(ev_fit_spec)
+
+                if not os.path.isdir(outdir):
+                    os.makedirs(outdir)
+
+                filenames = ['events'] + [
+                    imc.lower() for imc in imc_tables_formatted.keys()] + [
+                    imc.lower() + '_README' for imc in readmes.keys()] + [
+                    'fit_spectra_parameters', 'fit_spectra_parameters_README']
+
+                files = [event_table_formatted] + list(
+                    imc_tables_formatted.values()) + list(
+                    readmes.values()) + [df_fit_spectra_formatted, fit_readme]
+
+                if output_format != 'csv':
+                    output_format = 'xlsx'
+
+                for filename, df in dict(zip(filenames, files)).items():
+                    filepath = os.path.join(
+                        outdir, filename + '.%s' % output_format)
+                    if os.path.exists(filepath):
+                        if 'README' in filename:
+                            continue
+                        else:
+                            mode = 'a'
+                            header = False
+                    else:
+                        mode = 'w'
+                        header = True
+                        append_file(files_created, 'Tables', filepath)
+                    if output_format == 'csv':
+                        df.to_csv(filepath, index=False,
+                                  float_format=DEFAULT_FLOAT_FORMAT,
+                                  mode=mode, header=header)
+                    else:
+                        df.to_excel(filepath, index=False,
+                                    float_format=DEFAULT_FLOAT_FORMAT,
+                                    mode=mode, header=header)
 
     if ('report' in pcommands
             and processing_done
@@ -316,7 +392,7 @@ def main(args):
 
     # compare list of all commands with list of actual commands
     process_commands = set([
-        'assemble', 'process', 'report', 'shakemap', 'provenance'
+        'assemble', 'process', 'report', 'shakemap', 'provenance', 'export'
     ])
     pcommands = []
     if args.assemble:
@@ -353,7 +429,8 @@ def main(args):
                         workname = process_event(
                             outdir, event, pcommands, config,
                             input_directory, process_tag, logfile,
-                            files_created, args.format, args.status)
+                            files_created, args.format, args.status,
+                            args.recompute_metrics)
                         workspace_files.append(workname)
                     os._exit(0)
                 else:
@@ -368,7 +445,8 @@ def main(args):
                 workname = process_event(
                     outdir, event, pcommands,
                     config, input_directory, process_tag,
-                    logfile, files_created, args.format, args.status)
+                    logfile, files_created, args.format, args.status,
+                    args.recompute_metrics)
                 workspace_files.append(workname)
 
     # logging
@@ -402,155 +480,58 @@ def main(args):
     logging.info('%i workspace files created' % len(workspace_files))
 
     if 'export' in pcommands:
-        if not len(workspace_files):
-            # look for hdf files
-            workspace_files = find_workspace_files(outdir)
-
-        event_table = None
+        imc_table_names = [file.replace('_README', '')
+                           for file in os.listdir(outdir) if 'README' in file]
         imc_tables = {}
-        df_fit_spectra = pd.DataFrame()
-        for workspace_file in workspace_files:
-            workspace = StreamWorkspace.open(workspace_file)
-            if len(workspace.getStations()) == 0:
-                continue
-            labels = workspace.getLabels()
-            if 'unprocessed' not in labels:
-                fmt = ('Workspace file "%s" appears to have no unprocessed '
-                       'data. Skipping.')
-                print(fmt % workspace_file)
-                continue
-            labels.remove('unprocessed')
-            if not labels:
-                fmt = ('Workspace file "%s" appears to have no processed '
-                       'data. Skipping.')
-                print(fmt % workspace_file)
-                continue
-            eventid = workspace.getEventIds()[0]
-            logging.info(
-                'Creating tables for event %s...', eventid)
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore",
-                                      category=H5pyDeprecationWarning)
-                if args.recompute_metrics:
-                    del workspace.dataset.auxiliary_data.WaveFormMetrics
-                    del workspace.dataset.auxiliary_data.StationMetrics
-                    for eventid in workspace.getEventIds():
-                        workspace.calcMetrics(
-                            eventid, labels=labels, config=config)
-                    tevent_table, timc_tables, readmes = workspace.getTables(
-                        labels[0], config=config)
-                else:
-                    tevent_table, timc_tables, readmes = workspace.getTables(
-                        labels[0], config=None)
-                    ev_fit_spec, fit_readme = workspace.getFitSpectraTable(
-                        eventid, labels[0])
-                    df_fit_spectra = pd.concat((df_fit_spectra, ev_fit_spec))
-            if event_table is None:
-                event_table = tevent_table
-            else:
-                event_table = pd.concat([event_table, tevent_table])
-            if not imc_tables:
-                imc_tables = timc_tables
-            else:
-                for imc, imc_table in imc_tables.items():
-                    if imc in timc_tables:
-                        timc_table = timc_tables[imc]
-                        imc_tables[imc] = pd.concat([imc_table, timc_table])
-            workspace.close()
+        for file in imc_table_names:
+            imc_tables[file.replace('.%s' % args.format, '')] = pd.read_csv(
+                os.path.join(outdir, file))
+            if 'fit_spectra_parameters' in imc_tables:
+                del imc_tables['fit_spectra_parameters']
 
-        if event_table is not None:
-            # Set the precisions for the imc tables, event table, and fit_spectra
-            # table before writing
-            imc_tables_formatted = {}
-            for imc, imc_table in imc_tables.items():
-                imc_tables_formatted[imc] = set_precisions(imc_table)
-            event_table_formatted = set_precisions(event_table)
-            df_fit_spectra_formatted = set_precisions(df_fit_spectra)
+        event_table = pd.read_csv(os.path.join(outdir, 'events.csv'))
 
-        if args.export_dir is not None:
-            if not os.path.isdir(args.export_dir):
-                os.makedirs(args.export_dir)
-            outdir = args.export_dir
-
-        if event_table is not None:
-            if args.format == 'csv':
-                eventfile = os.path.join(outdir, 'events.csv')
-                event_table_formatted.to_csv(eventfile, index=False,
-                                             float_format=DEFAULT_FLOAT_FORMAT)
-                append_file(files_created, 'Event table', eventfile)
-                for imc, imc_table in imc_tables_formatted.items():
-                    imcfile = os.path.join(outdir, '%s.csv' % imc.lower())
-                    imc_table.to_csv(imcfile, index=False,
-                                     float_format=DEFAULT_FLOAT_FORMAT)
-                    append_file(files_created, 'IMC tables', imcfile)
-            else:
-                eventfile = os.path.join(outdir, 'events.xlsx')
-                event_table_formatted.to_excel(eventfile, index=False,
-                                               float_format=DEFAULT_FLOAT_FORMAT)
-                append_file(files_created, 'Event table', eventfile)
-                for imc, imc_table in imc_tables_formatted.items():
-                    imcfile = os.path.join(outdir, '%s.xlsx' % imc.lower())
-                    imc_table.to_excel(imcfile, index=False,
-                                       float_format=DEFAULT_FLOAT_FORMAT)
-                    append_file(files_created, 'IMC tables', imcfile)
-
-            for imc, readme_table in readmes.items():
-                readme_file = os.path.join(
-                    outdir, '%s.csv' % (imc.lower() + '_README'))
-                readme_table.to_csv(readme_file, index=False)
-                append_file(files_created, 'README tables', readme_file)
-
-            spectra_file = os.path.join(outdir, 'fit_spectra_parameters.csv')
-            df_fit_spectra_formatted.to_csv(spectra_file, index=False,
-                                            float_format=DEFAULT_FLOAT_FORMAT)
-            append_file(files_created, 'Fit spectra table', spectra_file)
-
-            fit_readme_file = os.path.join(
-                outdir, 'fit_spectra_parameters_README.csv')
-            fit_readme.to_csv(fit_readme_file, index=False)
-            append_file(files_created, 'README tables', fit_readme_file)
-
-            # make a regression plot of the most common imc/imt combination we
-            # can find
-            if not len(imc_tables):
-                msg = '''No IMC tables found. It is likely that no streams
-                passed checks. If you created reports for the events you
-                have been processing, check those to see if this is the case,
-                then adjust your configuration as necessary to process the data.
-                '''
-                logging.warning(msg)
-            else:
-                pref_imcs = ['GREATER_OF_TWO_HORIZONTALS', 'H1', 'H2']
-                pref_imts = ['PGA', 'PGV', 'SA(1.0)']
-                found_imc = None
-                found_imt = None
-                for imc in pref_imcs:
-                    if imc in imc_tables:
-                        for imt in pref_imts:
-                            if imt in imc_tables[imc].columns:
-                                found_imt = imt
-                                found_imc = imc
-                                break
-                        if found_imc:
+        # make a regression plot of the most common imc/imt combination we
+        # can find
+        if not len(imc_tables):
+            msg = '''No IMC tables found. It is likely that no streams
+            passed checks. If you created reports for the events you
+            have been processing, check those to see if this is the case,
+            then adjust your configuration as necessary to process the data.
+            '''
+            logging.warning(msg)
+        else:
+            pref_imcs = ['GREATER_OF_TWO_HORIZONTALS', 'H1', 'H2']
+            pref_imts = ['PGA', 'PGV', 'SA(1.0)']
+            found_imc = None
+            found_imt = None
+            for imc in pref_imcs:
+                if imc in imc_tables:
+                    for imt in pref_imts:
+                        if imt in imc_tables[imc].columns:
+                            found_imt = imt
+                            found_imc = imc
                             break
-                # now look for whatever IMC/IMTcombination we can find
-                if imc_tables and not found_imc:
-                    found_imc = list(imc_tables.keys())[0]
-                    table_cols = set(imc_tables[found_imc].columns)
-                    imtlist = list(table_cols - NON_IMT_COLS)
-                    found_imt = imtlist[0]
+                    if found_imc:
+                        break
+            # now look for whatever IMC/IMTcombination we can find
+            if imc_tables and not found_imc:
+                found_imc = list(imc_tables.keys())[0]
+                table_cols = set(imc_tables[found_imc].columns)
+                imtlist = list(table_cols - NON_IMT_COLS)
+                found_imt = imtlist[0]
 
-                if found_imc and found_imt:
-                    pngfile = '%s_%s.png' % (found_imc, found_imt)
-                    regression_file = os.path.join(outdir, pngfile)
-                    plot_regression(event_table, found_imc,
-                                    imc_tables[found_imc],
-                                    found_imt,
-                                    regression_file,
-                                    distance_metric='EpicentralDistance',
-                                    colormap='viridis_r')
-                    append_file(files_created,
-                                'Multi-event regression plot', regression_file)
+            if found_imc and found_imt:
+                pngfile = '%s_%s.png' % (found_imc, found_imt)
+                regression_file = os.path.join(outdir, pngfile)
+                plot_regression(event_table, found_imc,
+                                imc_tables[found_imc],
+                                found_imt,
+                                regression_file,
+                                distance_metric='EpicentralDistance',
+                                colormap='viridis_r')
+                append_file(files_created,
+                            'Multi-event regression plot', regression_file)
 
     if args.status:
         if args.status == 'short':

--- a/gmprocess/corner_frequencies.py
+++ b/gmprocess/corner_frequencies.py
@@ -54,7 +54,7 @@ def snr(st, same_horiz=True, bandwidth=20):
     """
     for tr in st:
         # Check for prior calculation of 'snr'
-        if not tr.hasParameter('snr'):
+        if not tr.hasCached('snr'):
             tr = compute_snr_trace(tr, bandwidth)
 
         # If it doesn't exist then it must have failed because it didn't have

--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -16,7 +16,7 @@ fetchers:
         # define the magnitude search threshold (km)
         dmag : 0.3
         # restrict the number of processed stations by
-        # using magnitude to set maximum station distance 
+        # using magnitude to set maximum station distance
         restrict_stations: false
     TurkeyFetcher:
         # define the distance search radius (km)

--- a/gmprocess/metrics/reduction/max.py
+++ b/gmprocess/metrics/reduction/max.py
@@ -1,18 +1,20 @@
 # Third party imports
 import numpy as np
+from obspy import Stream
 
 # Local imports
 from gmprocess.metrics.reduction.reduction import Reduction
+from gmprocess.stationstream import StationStream
 
 
 class Max(Reduction):
     """Class for calculation of maximum value."""
     def __init__(self, reduction_data, bandwidth=None, percentile=None,
-            period=None, smoothing=None):
+                 period=None, smoothing=None):
         """
         Args:
-            reduction_data (obspy.core.stream.Stream or numpy.ndarray): Intensity
-                    measurement component.
+            reduction_data (obspy.core.stream.Stream or numpy.ndarray):
+                Intensity measurement component.
             percentile (float): Percentile for rotation calculations. Default
                 is None.
             period (float): Period for smoothing (Fourier amplitude spectra)
@@ -23,7 +25,7 @@ class Max(Reduction):
                     is None.
         """
         super().__init__(reduction_data, bandwidth=None, percentile=None,
-                period=None, smoothing=None)
+                         period=None, smoothing=None)
         self.result = self.get_max()
 
     def get_max(self):
@@ -34,6 +36,10 @@ class Max(Reduction):
             maximums: Dictionary of maximum value for each channel.
         """
         maximums = {}
-        for trace in self.reduction_data:
-            maximums[trace.stats.channel] = np.abs(trace.max())
+        if isinstance(self.reduction_data, (Stream, StationStream)):
+            for trace in self.reduction_data:
+                maximums[trace.stats.channel] = np.abs(trace.max())
+        else:
+            for chan in self.reduction_data:
+                maximums[chan] = np.abs(self.reduction_data[chan]).max()
         return maximums

--- a/gmprocess/metrics/transform/differentiate.py
+++ b/gmprocess/metrics/transform/differentiate.py
@@ -30,9 +30,7 @@ class Differentiate(Transform):
         """
         stream = StationStream([])
         for trace in self.transform_data:
-            integrated_trace = trace.copy().differentiate()
-            integrated_trace.stats['units'] = 'acc'
-            strace = StationTrace(data=integrated_trace.data,
-                    header=integrated_trace.stats)
-            stream.append(strace)
+            differentiated_trace = trace.copy().differentiate()
+            differentiated_trace.stats['units'] = 'acc'
+            stream.append(differentiated_trace)
         return stream

--- a/gmprocess/metrics/transform/integrate.py
+++ b/gmprocess/metrics/transform/integrate.py
@@ -32,7 +32,5 @@ class Integrate(Transform):
         for trace in self.transform_data:
             integrated_trace = trace.copy().integrate()
             integrated_trace.stats['units'] = 'vel'
-            strace = StationTrace(data=integrated_trace.data,
-                    header=integrated_trace.stats)
-            stream.append(strace)
+            stream.append(integrated_trace)
         return stream

--- a/gmprocess/phase.py
+++ b/gmprocess/phase.py
@@ -322,7 +322,7 @@ def pick_baer(stream, picker_config=None, config=None):
     return (minloc, mean_snr)
 
 
-def pick_travel(stream, origin, picker_config=None):
+def pick_travel(stream, origin, model=None, picker_config=None):
     '''Use TauP travel time model to find P-Phase arrival time.
 
     Args:
@@ -330,17 +330,17 @@ def pick_travel(stream, origin, picker_config=None):
             StationStream containing 1 or more channels of waveforms.
         origin (ScalarEvent):
             Event origin/magnitude information.
-        picker_config (dict):
-            Dictionary containing picker configuration.
+        model (TauPyModel):
+            TauPyModel object for computing travel times.
     Returns:
         tuple:
             - Best estimate for p-wave arrival time (s since start of trace).
             - Mean signal to noise ratio based on the pick.
     '''
-    if picker_config is None:
-        picker_config = get_config(section='pickers')
-    model = picker_config['travel_time']['model']
-    model = TauPyModel(model=model)
+    if model is None:
+        if picker_config is None:
+            picker_config = get_config(section='pickers')
+        model = TauPyModel(picker_config['travel_time']['model'])
     if stream[0].stats.starttime == NAN_TIME:
         return (-1, 0)
     lat = origin.latitude

--- a/gmprocess/plot.py
+++ b/gmprocess/plot.py
@@ -615,7 +615,8 @@ def summary_plots(st, directory, origin):
             trace_status = " (passed)"
         trace_title = tr.get_id() + trace_status
         ax[j].set_title(trace_title)
-        dtimes = tr.times('utcdatetime') - tr.stats.starttime
+        dtimes = np.linspace(
+            0, tr.stats.endtime - tr.stats.starttime, tr.stats.npts)
         ax[j].plot(dtimes, tr.data, 'k', linewidth=0.5)
 
         # Show signal split as vertical dashed line
@@ -632,7 +633,9 @@ def summary_plots(st, directory, origin):
         # ---------------------------------------------------------------------
         # Velocity time series plot
         tr_vel = st_vel[j]
-        dtimes = tr_vel.times('utcdatetime') - tr_vel.stats.starttime
+        dtimes = np.linspace(
+            0, tr_vel.stats.endtime - tr_vel.stats.starttime, tr_vel.stats.npts
+        )
         ax[j + ntrace].plot(dtimes, tr_vel.data, 'k', linewidth=0.5)
 
         # Show signal split as vertical dashed line

--- a/gmprocess/pretesting.py
+++ b/gmprocess/pretesting.py
@@ -54,8 +54,8 @@ def check_sta_lta(st, sta_length=1.0, lta_length=20.0, threshold=5.0):
         sr = tr.stats.sampling_rate
         nlta = lta_length * sr + 1
         if len(tr) >= nlta:
-            sta_lta = classic_sta_lta(tr, sta_length * sr + 1, nlta)
-            if max(sta_lta) < threshold:
+            sta_lta = classic_sta_lta(tr.data, sta_length * sr + 1, nlta)
+            if sta_lta.max() < threshold:
                 tr.fail('Failed sta/lta check because threshold sta/lta '
                         'is not exceeded.')
         else:

--- a/gmprocess/stationstream.py
+++ b/gmprocess/stationstream.py
@@ -318,10 +318,10 @@ class StationStream(Stream):
                 'Parameter %s not found in StationStream' % param_id)
         return self.parameters[param_id]
 
-    def getProvenanceDocuments(self):
+    def getProvenanceDocuments(self, base_prov=None):
         provdocs = []
         for trace in self.traces:
-            provdoc = trace.getProvenanceDocument()
+            provdoc = trace.getProvenanceDocument(base_prov)
             provdocs.append(provdoc)
         return provdocs
 

--- a/gmprocess/stationtrace.py
+++ b/gmprocess/stationtrace.py
@@ -1,5 +1,6 @@
 # stdlib imports
 import json
+import copy
 import logging
 from datetime import datetime
 import getpass
@@ -384,12 +385,15 @@ class StationTrace(Trace):
         """
         return self.provenance
 
-    def getProvenanceDocument(self):
-        pr = prov.model.ProvDocument()
-        pr.add_namespace(*NS_SEIS)
-        pr = _get_person_agent(pr)
-        pr = _get_software_agent(pr)
-        pr = _get_waveform_entity(self, pr)
+    def getProvenanceDocument(self, base_prov=None):
+        if base_prov is None:
+            pr = prov.model.ProvDocument()
+            pr.add_namespace(*NS_SEIS)
+            pr = _get_person_agent(pr)
+            pr = _get_software_agent(pr)
+            pr = _get_waveform_entity(self, pr)
+        else:
+            pr = _get_waveform_entity(self, copy.deepcopy(base_prov))
         sequence = 1
         for provdict in self.getAllProvenance():
             provid = provdict['prov_id']

--- a/gmprocess/streamcollection.py
+++ b/gmprocess/streamcollection.py
@@ -572,15 +572,16 @@ class StreamCollection(object):
 
         # If arguments are None, check the config
         # If not in the config, use the default values at top of the file
-        if max_dist_tolerance is None:
-            max_dist_tolerance = get_config('duplicate')['max_dist_tolerance']
-
-        if process_level_preference is None:
-            process_level_preference = \
-                get_config('duplicate')['process_level_preference']
-
-        if format_preference is None:
-            format_preference = get_config('duplicate')['format_preference']
+        preferences = {
+            'max_dist_tolerance': max_dist_tolerance,
+            'process_level_preference': process_level_preference,
+            'format_preference': format_preference}
+        default_config = None
+        for key, val in preferences.items():
+            if val is None:
+                if default_config is None:
+                    default_config = get_config()
+                preferences[key] = default_config['duplicate'][key]
 
         stream_params = gather_stream_parameters(self.streams)
 
@@ -593,15 +594,16 @@ class StreamCollection(object):
         for tr_to_add in traces:
             is_duplicate = False
             for tr_pref in preferred_traces:
-                if are_duplicates(tr_to_add, tr_pref, max_dist_tolerance):
+                if are_duplicates(tr_to_add, tr_pref,
+                                  preferences['max_dist_tolerance']):
                     is_duplicate = True
                     break
 
             if is_duplicate:
                 if choose_preferred(
                         tr_to_add, tr_pref,
-                        process_level_preference,
-                        format_preference) == tr_to_add:
+                        preferences['process_level_preference'],
+                        preferences['format_preference']) == tr_to_add:
                     preferred_traces.remove(tr_pref)
                     logging.info('Trace %s (%s) is a duplicate and '
                                  'has been removed from the StreamCollection.'

--- a/gmprocess/windows.py
+++ b/gmprocess/windows.py
@@ -99,10 +99,8 @@ def window_checks(st, min_noise_duration=0.5, min_signal_duration=5.0):
         if isinstance(split_prov, list):
             split_prov = split_prov[0]
         split_time = split_prov['split_time']
-        noise = tr.copy().trim(endtime=split_time)
-        signal = tr.copy().trim(starttime=split_time)
-        noise_duration = noise.stats.endtime - noise.stats.starttime
-        signal_duration = signal.stats.endtime - signal.stats.starttime
+        noise_duration = split_time - tr.stats.starttime
+        signal_duration = tr.stats.endtime - split_time
         if noise_duration < min_noise_duration:
             tr.fail('Failed noise window duration check.')
         if signal_duration < min_signal_duration:
@@ -112,7 +110,7 @@ def window_checks(st, min_noise_duration=0.5, min_signal_duration=5.0):
 
 
 def signal_split(
-        st, origin,
+        st, origin, model=None,
         picker_config=None,
         config=None):
     """
@@ -130,6 +128,8 @@ def signal_split(
             Stream of data.
         origin (ScalarEvent):
             ScalarEvent object.
+        model (TauPyModel):
+            TauPyModel object for computing travel times.
         picker_config (dict):
             Dictionary containing picker configuration information.
         config (dict):
@@ -144,8 +144,7 @@ def signal_split(
     if config is None:
         config = get_config()
 
-    loc, mean_snr = pick_travel(st, origin,
-                                picker_config=picker_config)
+    loc, mean_snr = pick_travel(st, origin, model)
     if loc > 0:
         tsplit = st[0].stats.starttime + loc
         preferred_picker = 'travel_time'

--- a/gmprocess/zero_crossings.py
+++ b/gmprocess/zero_crossings.py
@@ -1,5 +1,4 @@
 import numpy as np
-import logging
 
 
 def check_zero_crossings(st, min_crossings=1.0):
@@ -26,26 +25,27 @@ def check_zero_crossings(st, min_crossings=1.0):
         # Make a copy of the trace to trim it before counting crossings; we do
         # not want to modify the trace but we only want to count the crossings
         # within the trimmed window
-        trcopy = tr.copy()
 
         if tr.hasParameter('signal_end'):
             etime = tr.getParameter('signal_end')['end_time']
             split_time = tr.getParameter('signal_split')['split_time']
 
-            trcopy.trim(starttime=split_time, endtime=etime)
+            sig_start = int((split_time - tr.stats.starttime) / tr.stats.delta)
+            sig_end = int((etime - tr.stats.starttime) / tr.stats.delta)
+            tr_data = tr.data[sig_start:sig_end]
 
-        zarray = np.multiply(trcopy.data[0:-1], trcopy.data[1:])
-        zindices = [i for (i, z) in enumerate(zarray) if z < 0]
-        zero_count_tr = len(zindices)
+            zarray = np.multiply(tr_data[0:-1], tr_data[1:])
+            zindices = [i for (i, z) in enumerate(zarray) if z < 0]
+            zero_count_tr = len(zindices)
 
-        z_rate = zero_count_tr / dur
+            z_rate = zero_count_tr / dur
 
-        # Put results back into the original trace, not the copy
-        tr.setParameter('ZeroCrossingRate',
-                        {'crossing_rate': z_rate})
+            # Put results back into the original trace, not the copy
+            tr.setParameter('ZeroCrossingRate',
+                            {'crossing_rate': z_rate})
 
-        # Fail if zero crossing rate is too low
-        if z_rate <= min_crossings:
-            tr.fail('Zero crossing rate too low.')
+            # Fail if zero crossing rate is too low
+            if z_rate <= min_crossings:
+                tr.fail('Zero crossing rate too low.')
 
     return st

--- a/tests/gmprocess/io/asdf/stream_workspace_test.py
+++ b/tests/gmprocess/io/asdf/stream_workspace_test.py
@@ -256,7 +256,8 @@ def test_metrics():
     newconfig = config.copy()
     newconfig['processing'].append({'NNet_QA': {'acceptance_threshold': 0.5,
                                                 'model_name': 'CantWell'}})
-    processed_streams = process_streams(raw_streams, event, config=newconfig)
+    processed_streams = process_streams(raw_streams.copy(), event,
+                                        config=newconfig)
 
     tdir = tempfile.mkdtemp()
     try:

--- a/tests/gmprocess/io/bhrc/bhrc_test.py
+++ b/tests/gmprocess/io/bhrc/bhrc_test.py
@@ -28,9 +28,7 @@ def test_bhrc():
     for stream in raw_streams:
         summary = StationSummary.from_config(stream)
         cmp_value = peaks[summary.station_code]
-        imt = summary.pgms.loc[summary.pgms.IMT == 'PGA']
-        g2h = imt.loc[imt.IMC == 'GREATER_OF_TWO_HORIZONTALS']
-        pga = g2h['Result'].tolist()[0]
+        pga = summary.pgms.loc['PGA', 'GREATER_OF_TWO_HORIZONTALS'].tolist()[0]
         np.testing.assert_almost_equal(cmp_value, pga)
     #     fmt = '%s: %.3f, %.3f'
     #     tpl = (stream[0].stats.station,

--- a/tests/gmprocess/metrics/imc/channels_test.py
+++ b/tests/gmprocess/metrics/imc/channels_test.py
@@ -19,13 +19,13 @@ def test_channels():
     stream_v2 = read_geonet(datafile_v2)[0]
     station_summary = StationSummary.from_stream(stream_v2,
                                                  ['channels'], ['pga'])
-    channel = station_summary.pgms[station_summary.pgms.IMT == 'PGA']
+    pgms = station_summary.pgms
     np.testing.assert_almost_equal(
-        channel[channel.IMC == 'H2'].Result.iloc[0], 81.28979591836733, decimal=1)
+        pgms.loc['PGA', 'H2'].Result, 81.28979591836733, decimal=1)
     np.testing.assert_almost_equal(
-        channel[channel.IMC == 'H1'].Result.iloc[0], 99.3173469387755, decimal=1)
+        pgms.loc['PGA', 'H1'].Result, 99.3173469387755, decimal=1)
     np.testing.assert_almost_equal(
-        channel[channel.IMC == 'Z'].Result.iloc[0], 183.89693877551022, decimal=1)
+        pgms.loc['PGA', 'Z'].Result, 183.89693877551022, decimal=1)
 
 
 if __name__ == '__main__':

--- a/tests/gmprocess/metrics/imc/gmrotd_test.py
+++ b/tests/gmprocess/metrics/imc/gmrotd_test.py
@@ -25,7 +25,7 @@ def test_gmrotd():
                                                  ['gmrotd0', 'gmrotd50',
                                                   'gmrotd100'], ['pga'])
     pgms = station_summary.pgms
-    assert 'GMROTD(50.0)' in pgms.IMC.tolist()
+    assert 'GMROTD(50.0)' in pgms.index.get_level_values(1)
 
 
 def test_exceptions():

--- a/tests/gmprocess/metrics/imc/greater_of_two_horizontals_test.py
+++ b/tests/gmprocess/metrics/imc/greater_of_two_horizontals_test.py
@@ -19,8 +19,8 @@ def test_greater_of_two_horizontals():
     stream_v2 = read_geonet(datafile_v2)[0]
     station_summary = StationSummary.from_stream(stream_v2,
                                                  ['greater_of_two_horizontals'], ['pga'])
-    station = station_summary.pgms[station_summary.pgms.IMT == 'PGA']
-    greater = station[station.IMC == 'GREATER_OF_TWO_HORIZONTALS'].Result.iloc[0]
+    pgms = station_summary.pgms
+    greater = pgms.loc['PGA', 'GREATER_OF_TWO_HORIZONTALS'].Result
     np.testing.assert_almost_equal(greater, 99.3173469387755, decimal=1)
 
 

--- a/tests/gmprocess/metrics/imc/radial_transverse_test.py
+++ b/tests/gmprocess/metrics/imc/radial_transverse_test.py
@@ -79,8 +79,8 @@ def test_radial_transverse():
     summary = StationSummary.from_stream(
         st2, ['radial_transverse'], ['pga'], origin)
     pgmdf = summary.pgms
-    R = pgmdf[(pgmdf.IMT == 'PGA') & (pgmdf.IMC == 'HNR')].Result.iloc[0]
-    T = pgmdf[(pgmdf.IMT == 'PGA') & (pgmdf.IMC == 'HNT')].Result.iloc[0]
+    R = pgmdf.loc['PGA', 'HNR'].Result
+    T = pgmdf.loc['PGA', 'HNT'].Result
     np.testing.assert_almost_equal(
         pgms[0], sp.g * R)
 
@@ -136,20 +136,16 @@ def test_radial_transverse():
     copy1[0].stats.channel = copy1[0].stats.channel[:-1] + '3'
     pgms = StationSummary.from_stream(
         copy1, ['radial_transverse'], ['pga'], origin).pgms
-    assert np.isnan(pgms[(pgms.IMT == 'PGA') & (
-        pgms.IMC == 'HNR')].Result.iloc[0])
-    assert np.isnan(pgms[(pgms.IMT == 'PGA') & (
-        pgms.IMC == 'HNT')].Result.iloc[0])
+    assert np.isnan(pgms.loc['PGA', 'HNR'].Result)
+    assert np.isnan(pgms.loc['PGA', 'HNT'].Result)
 
     # Test failure case when channels are not orthogonal
     copy3 = st2.copy()
     copy3[0].stats.standard.horizontal_orientation = 100
     pgms = StationSummary.from_stream(
         copy3, ['radial_transverse'], ['pga'], origin).pgms
-    assert np.isnan(pgms[(pgms.IMT == 'PGA') & (
-        pgms.IMC == 'HNR')].Result.iloc[0])
-    assert np.isnan(pgms[(pgms.IMT == 'PGA') & (
-        pgms.IMC == 'HNT')].Result.iloc[0])
+    assert np.isnan(pgms.loc['PGA', 'HNR'].Result)
+    assert np.isnan(pgms.loc['PGA', 'HNT'].Result)
 
 
 if __name__ == '__main__':

--- a/tests/gmprocess/metrics/imc/rotd_test.py
+++ b/tests/gmprocess/metrics/imc/rotd_test.py
@@ -85,12 +85,11 @@ def test_rotd():
     )
 
     pgms = station.pgms
-    ROTD50 = pgms[pgms.IMC == 'ROTD(50.0)']
-    pga = ROTD50[ROTD50.IMT == 'PGA'].Result.iloc[0]
-    pgv = ROTD50[ROTD50.IMT == 'PGV'].Result.iloc[0]
-    SA10 = ROTD50[ROTD50.IMT == 'SA(1.000)'].Result.iloc[0]
-    SA03 = ROTD50[ROTD50.IMT == 'SA(0.300)'].Result.iloc[0]
-    SA30 = ROTD50[ROTD50.IMT == 'SA(3.000)'].Result.iloc[0]
+    pga = pgms.loc['PGA', 'ROTD(50.0)'].Result
+    pgv = pgms.loc['PGV', 'ROTD(50.0)'].Result
+    SA10 = pgms.loc['SA(1.000)', 'ROTD(50.0)'].Result
+    SA03 = pgms.loc['SA(0.300)', 'ROTD(50.0)'].Result
+    SA30 = pgms.loc['SA(3.000)', 'ROTD(50.0)'].Result
     np.testing.assert_allclose(pga, target_pga50, atol=0.1)
     np.testing.assert_allclose(SA10, target_sa1050, atol=0.1)
     np.testing.assert_allclose(pgv, target_pgv50, atol=0.1)
@@ -105,8 +104,7 @@ def test_exceptions():
     stream_v2 = read_geonet(datafile_v2)[0]
     stream1 = stream_v2.select(channel="HN1")
     pgms = StationSummary.from_stream(stream1, ['rotd50'], ['pga']).pgms
-    assert np.isnan(pgms[(pgms.IMT == 'PGA') & (
-        pgms.IMC == 'ROTD(50.0)')].Result.iloc[0])
+    assert np.isnan(pgms.loc['PGA', 'ROTD(50.0)'].Result)
 
 
 if __name__ == '__main__':

--- a/tests/gmprocess/metrics/imt/arias_test.py
+++ b/tests/gmprocess/metrics/imt/arias_test.py
@@ -68,8 +68,7 @@ def test_arias():
     station = StationSummary.from_stream(
         stream, ['ARITHMETIC_MEAN'], ['arias'])
     pgms = station.pgms
-    Ia = pgms[(pgms.IMT == 'ARIAS') & (
-        pgms.IMC == 'ARITHMETIC_MEAN')].Result.tolist()[0]
+    Ia = pgms.loc['ARIAS', 'ARITHMETIC_MEAN'].Result
     # the target has only one decimal place and is in cm/s/s
     Ia = Ia * 100
     np.testing.assert_almost_equal(Ia, target_IA, decimal=1)

--- a/tests/gmprocess/metrics/imt/duration_test.py
+++ b/tests/gmprocess/metrics/imt/duration_test.py
@@ -68,8 +68,7 @@ def test_duration():
     station = StationSummary.from_stream(
         stream, ['ARITHMETIC_MEAN'], ['duration'])
     pgms = station.pgms
-    d595 = pgms[(pgms.IMT == 'DURATION') & (
-        pgms.IMC == 'ARITHMETIC_MEAN')].Result.tolist()[0]
+    d595 = pgms.loc['DURATION', 'ARITHMETIC_MEAN'].Result
 
     np.testing.assert_allclose(d595, target_d595, atol=1e-4, rtol=1e-4)
 
@@ -83,8 +82,8 @@ def test_duration():
         ['duration']
     )
     # Currently disallowed
-    assert 'gmrotd' not in station.pgms['IMC']
-    assert 'rotd50' not in station.pgms['IMC']
+    assert 'gmrotd' not in station.pgms.index.get_level_values(1)
+    assert 'rotd50' not in station.pgms.index.get_level_values(1)
     print(station)
 
 

--- a/tests/gmprocess/metrics/imt/fas_test.py
+++ b/tests/gmprocess/metrics/imt/fas_test.py
@@ -74,7 +74,7 @@ def test_fas():
     pgms = summary.pgms
     for idx, f in enumerate(freqs):
         fstr = 'FAS(%.3f)' % (1/f)
-        fval = pgms[pgms.IMT == fstr].Result.tolist()[0]
+        fval = pgms.loc[fstr, 'QUADRATIC_MEAN'].Result
         np.testing.assert_allclose(
             fval,
             fas[idx] / len(stream[0].data),

--- a/tests/gmprocess/metrics/imt/pga_test.py
+++ b/tests/gmprocess/metrics/imt/pga_test.py
@@ -25,13 +25,13 @@ def test_pga():
              'gmrotd100', 'gmrotd0', 'rotd50', 'geometric_mean',
              'arithmetic_mean'],
             ['pga', 'sa1.0', 'saincorrect'])
-    pga_df = station_summary.pgms[station_summary.pgms.IMT == 'PGA']
-    AM = pga_df[pga_df.IMC == 'ARITHMETIC_MEAN'].Result.iloc[0]
-    GM = pga_df[pga_df.IMC == 'GEOMETRIC_MEAN'].Result.iloc[0]
-    HN1 = pga_df[pga_df.IMC == 'H1'].Result.iloc[0]
-    HN2 = pga_df[pga_df.IMC == 'H2'].Result.iloc[0]
-    HNZ = pga_df[pga_df.IMC == 'Z'].Result.iloc[0]
-    greater = pga_df[pga_df.IMC == 'GREATER_OF_TWO_HORIZONTALS'].Result.iloc[0]
+    pga_df = station_summary.pgms.loc['PGA']
+    AM = pga_df.loc['ARITHMETIC_MEAN'].Result
+    GM = pga_df.loc['GEOMETRIC_MEAN'].Result
+    HN1 = pga_df.loc['H1'].Result
+    HN2 = pga_df.loc['H2'].Result
+    HNZ = pga_df.loc['Z'].Result
+    greater = pga_df.loc['GREATER_OF_TWO_HORIZONTALS'].Result
     np.testing.assert_allclose(
         AM, 90.242335558014219, rtol=1e-3)
     np.testing.assert_allclose(

--- a/tests/gmprocess/metrics/imt/pgv_test.py
+++ b/tests/gmprocess/metrics/imt/pgv_test.py
@@ -36,10 +36,10 @@ def test_pgv():
                                                      ['channels', 'greater_of_two_horizontals',
                                                          'gmrotd50'],
                                                      ['pgv', 'sa1.0', 'saincorrect'])
-    pgv_df = station_summary.pgms[station_summary.pgms.IMT == 'PGV']
-    HN1 = pgv_df[pgv_df.IMC == 'H1'].Result.iloc[0]
-    HN2 = pgv_df[pgv_df.IMC == 'H2'].Result.iloc[0]
-    HNZ = pgv_df[pgv_df.IMC == 'Z'].Result.iloc[0]
+    pgv_df = station_summary.pgms.loc['PGV']
+    HN1 = pgv_df.loc['H1'].Result
+    HN2 = pgv_df.loc['H2'].Result
+    HNZ = pgv_df.loc['Z'].Result
     np.testing.assert_almost_equal(HN2, pgv_target['H2'])
     np.testing.assert_almost_equal(HN1, pgv_target['H1'])
     np.testing.assert_almost_equal(HNZ, pgv_target['Z'])

--- a/tests/gmprocess/metrics/imt/sa_test.py
+++ b/tests/gmprocess/metrics/imt/sa_test.py
@@ -31,21 +31,21 @@ def test_sa():
              'gmrotd50', 'channels'],
             ['sa1.0', 'saincorrect'])
     pgms = station_summary.pgms
-    assert 'SA(1.000)' in pgms.IMT.tolist()
+    assert 'SA(1.000)' in pgms.index.get_level_values(0)
     np.testing.assert_allclose(
-        pgms[pgms['IMC'] == 'ARITHMETIC_MEAN'].Result.iloc[0],
+        pgms.loc['SA(1.000)', 'ARITHMETIC_MEAN'].Result,
         110.47168962900042
     )
     np.testing.assert_allclose(
-        pgms[pgms['IMC'] == 'GEOMETRIC_MEAN'].Result.iloc[0],
+        pgms.loc['SA(1.000)', 'GEOMETRIC_MEAN'].Result,
         107.42183990654802
     )
     np.testing.assert_allclose(
-        pgms[pgms['IMC'] == 'ROTD(50.0)'].Result.iloc[0],
+        pgms.loc['SA(1.000)', 'ROTD(50.0)'].Result,
         106.03202302692158
     )
     np.testing.assert_allclose(
-        pgms[pgms['IMC'] == 'ROTD(100.0)'].Result.iloc[0],
+        pgms.loc['SA(1.000)', 'ROTD(100.0)'].Result,
         146.90233501240979
     )
 

--- a/tests/gmprocess/metrics/metrics_controller_test.py
+++ b/tests/gmprocess/metrics/metrics_controller_test.py
@@ -38,15 +38,13 @@ def test_controller():
                    'ARITHMETIC_MEAN', 'H1', 'H2', 'Z',
                    'GREATER_OF_TWO_HORIZONTALS', 'QUADRATIC_MEAN']
     for col in ['PGA', 'PGV', 'SA(1.000)', 'SA(2.000)', 'SA(0.300)']:
-        imt = pgms.loc[pgms['IMT'] == col]
-        imcs = imt['IMC'].tolist()
+        imcs = pgms.loc[col].index.tolist()
         assert len(imcs) == len(target_imcs)
         np.testing.assert_array_equal(np.sort(imcs), np.sort(target_imcs))
 
     # testing for fas
     for col in ['FAS(1.000)', 'FAS(2.000)', 'FAS(0.300)']:
-        imt = pgms.loc[pgms['IMT'] == col]
-        imcs = imt['IMC'].tolist()
+        imcs = pgms.loc[col].index.tolist()
         assert len(imcs) == 3
         np.testing.assert_array_equal(
             np.sort(imcs),
@@ -54,8 +52,7 @@ def test_controller():
         )
 
     # testing for arias
-    imt = pgms.loc[pgms['IMT'] == 'ARIAS']
-    imcs = imt['IMC'].tolist()
+    imcs = pgms.loc['ARIAS'].index.tolist()
     assert len(imcs) == 1
     np.testing.assert_array_equal(np.sort(imcs), ['ARITHMETIC_MEAN'])
     _validate_steps(m1.step_sets, 'acc')
@@ -72,15 +69,13 @@ def test_controller():
                    'ARITHMETIC_MEAN', 'QUADRATIC_MEAN', 'H1', 'H2',
                    'Z', 'GREATER_OF_TWO_HORIZONTALS']
     for col in ['PGA', 'PGV', 'SA(1.000)', 'SA(2.000)', 'SA(0.300)']:
-        imt = pgms.loc[pgms['IMT'] == col]
-        imcs = imt['IMC'].tolist()
+        imcs = pgms.loc[col].index.tolist()
         assert len(imcs) == len(target_imcs)
         np.testing.assert_array_equal(np.sort(imcs), np.sort(target_imcs))
 
     # testing for fas
     for col in ['FAS(1.000)', 'FAS(2.000)', 'FAS(0.300)']:
-        imt = pgms.loc[pgms['IMT'] == col]
-        imcs = imt['IMC'].tolist()
+        imcs = pgms.loc[col].index.tolist()
         assert len(imcs) == 3
         np.testing.assert_array_equal(
             np.sort(imcs),
@@ -88,8 +83,7 @@ def test_controller():
         )
 
     # testing for arias
-    imt = pgms.loc[pgms['IMT'] == 'ARIAS']
-    imcs = imt['IMC'].tolist()
+    imcs = pgms.loc['ARIAS'].index.tolist()
     assert len(imcs) == 1
     np.testing.assert_array_equal(np.sort(imcs), ['ARITHMETIC_MEAN'])
     _validate_steps(m.step_sets, 'vel')
@@ -189,17 +183,16 @@ def test_end_to_end():
         ('SA(1.000)', 'GREATER_OF_TWO_HORIZONTALS', 136.25041187387063)
     ]
     pgms = m.pgms
-    assert len(pgms['IMT'].tolist()) == len(test_pgms)
+    assert len(pgms) == len(test_pgms)
     for target in test_pgms:
         target_imt = target[0]
         target_imc = target[1]
         value = target[2]
-        sub_imt = pgms.loc[pgms['IMT'] == target_imt]
-        df = sub_imt.loc[sub_imt['IMC'] == target_imc]
-        assert len(df['IMT'].tolist()) == 1
+        df = pgms.loc[target_imt, target_imc]
+        assert len(df) == 1
 
         np.testing.assert_array_almost_equal(
-            df['Result'].tolist()[0], value,
+            df['Result'], value,
             decimal=10)
 
 

--- a/tests/gmprocess/metrics/stationsummary_test.py
+++ b/tests/gmprocess/metrics/stationsummary_test.py
@@ -89,11 +89,8 @@ def test_stationsummary():
     pgms = stream_summary.pgms
     for imt_str in test_pgms:
         for imc_str in test_pgms[imt_str]:
-            imt = pgms.loc[pgms['IMT'] == imt_str]
-            imc = imt.loc[imt['IMC'] == imc_str]
-            results = imc.Result.tolist()
-            assert len(results) == 1
-            np.testing.assert_almost_equal(results[0], test_pgms[imt_str][imc_str],
+            result = pgms.loc[imt_str, imc_str].Result
+            np.testing.assert_almost_equal(result, test_pgms[imt_str][imc_str],
                                            decimal=10)
 
     # Test with fas


### PR DESCRIPTION
- Several `StreamWorkspace` methods (`calcMetrics`, `getTables`) now take in an optional `streams` argument. This is useful to avoid having to run `getStreams()` again inside the methods when we already usually have the StreamCollection object available when running `gmprocess`.
- Several places in the code (getTables, metrics controller, fit spectra tables) were building DataFrames by appending individual rows one at a time. This is inefficient, so instead we add individual items to a dictionary. Then the dictionary is converted to a DataFrame at the end.
- PGMs are now stored in a DataFrame that is multi-indexed with both IMT and IMC. Trying to get pgms for a certain IMT/IMC combination is significantly faster with this structure.
- StationSummary "summary" attribute is not calculated by default now since it's not always needed when running `gmprocess`.
- Fix for `gmprocess.metrics.reduction.max` with SA.
- TauPyModel object is created at `process_streams` level instead of `pick_travel` to avoid initializing a new object for every stream that is processed.
- STA/LTA check sped up by using .max() instead of max(), and explicitly passing `tr.data` to avoid creating new numpy array.
- Polynomial baseline correction sped up by avoiding loop.
- `trace.getProvenanceDocument()` now takes in a base document to avoid finding and setting all of the software and user information for every trace.
- Avoids copying of traces in various locations, including `window_checks`, `remove_response`, `differentiate`, `integrate`, and `zero_crossings`
- Fixed bug where `corner_frequencies.py` was using `tr.hasParameter('snr')` instead of `tr.hasCached('snr')` resulting in the SNR being computed multiple times.
- Refactored `--export` command in `gmprocess` to occur on the event level.
- Tests changed to match new IMT/IMC pgms structure.