### PR TITLE
Minimum frequency function of magnitude.

### DIFF
--- a/gmprocess/data/testdata/config_min_freq_0p2.yml
+++ b/gmprocess/data/testdata/config_min_freq_0p2.yml
@@ -208,7 +208,7 @@ processing:
         bandwidth: 20.0
         check:
             threshold: 3.0
-            min_freq: 'f0'  # Either a float or 'f0'. If 'f0', then the Brune
+            min_freq: 0.2  # Either a float or 'f0'. If 'f0', then the Brune
             # corner frequency of the earthquake will be used as the minimum
             # frequency for the SNR check.
             max_freq: 5.0

--- a/tests/gmprocess/corner_frequencies_test.py
+++ b/tests/gmprocess/corner_frequencies_test.py
@@ -66,9 +66,11 @@ def test_corner_frequencies():
         d for d in pconfig if list(d.keys())[0] == 'compute_snr'
     ]
     snr_config = test[0]['compute_snr']
+    snr_config['check']['min_freq'] = 0.2
     for stream in processed_streams:
         stream = compute_snr(
             stream,
+            mag=origin.magnitude,
             **snr_config
         )
 

--- a/tests/gmprocess/io/asdf/asdf_layout_test.py
+++ b/tests/gmprocess/io/asdf/asdf_layout_test.py
@@ -15,7 +15,11 @@ from gmprocess.io.test_utils import read_data_dir
 from gmprocess.io.asdf.stream_workspace import StreamWorkspace
 from gmprocess.processing import process_streams
 from gmprocess.io.asdf.core import write_asdf
-from gmprocess.config import get_config
+from gmprocess.io.fetch_utils import update_config
+
+
+datapath = os.path.join('data', 'testdata')
+datadir = pkg_resources.resource_filename('gmprocess', datapath)
 
 
 def generate_workspace():
@@ -38,7 +42,8 @@ def generate_workspace():
     write_asdf(tfilename, raw_data, event, label="unprocessed")
     del raw_data
 
-    config = get_config()
+    config = update_config(os.path.join(datadir, 'config_min_freq_0p2.yml'))
+
     workspace = StreamWorkspace.open(tfilename)
     raw_streams = workspace.getStreams(EVENTID, labels=['unprocessed'])
     pstreams = process_streams(raw_streams, event, config=config)
@@ -65,7 +70,7 @@ def test_layout():
         'group': h5py.Group,
         'dataset': h5py.Dataset,
     }
-    
+
     tfilename = setup_module.tfilename
     h5 = h5py.File(tfilename, "r")
 

--- a/tests/gmprocess/io/asdf/stream_workspace_test.py
+++ b/tests/gmprocess/io/asdf/stream_workspace_test.py
@@ -6,15 +6,15 @@ import shutil
 import time
 import tempfile
 import warnings
+import pkg_resources
 
 from gmprocess.io.asdf.stream_workspace import StreamWorkspace
 from gmprocess.io.read import read_data
 from gmprocess.processing import process_streams
-from gmprocess.config import get_config
 from gmprocess.io.test_utils import read_data_dir
 from gmprocess.metrics.station_summary import StationSummary
 from gmprocess.streamcollection import StreamCollection
-from gmprocess.io.fetch_utils import get_rupture_file
+from gmprocess.io.fetch_utils import get_rupture_file, update_config
 
 from h5py.h5py_warnings import H5pyDeprecationWarning
 from yaml import YAMLLoadWarning
@@ -22,6 +22,10 @@ from yaml import YAMLLoadWarning
 import numpy as np
 import pandas as pd
 import pytest
+
+
+datapath = os.path.join('data', 'testdata')
+datadir = pkg_resources.resource_filename('gmprocess', datapath)
 
 
 def compare_streams(instream, outstream):
@@ -93,7 +97,8 @@ def test_workspace():
             warnings.filterwarnings("ignore", category=H5pyDeprecationWarning)
             warnings.filterwarnings("ignore", category=YAMLLoadWarning)
             warnings.filterwarnings("ignore", category=FutureWarning)
-            config = get_config()
+            config = update_config(
+                os.path.join(datadir, 'config_min_freq_0p2.yml'))
             tfile = os.path.join(tdir, 'test.hdf')
             raw_streams = []
             for dfile in datafiles:
@@ -216,7 +221,7 @@ def test_metrics2():
                                      '*')
     datadir = os.path.split(datafiles[0])[0]
     raw_streams = StreamCollection.from_directory(datadir)
-    config = get_config()
+    config = update_config(os.path.join(datadir, 'config_min_freq_0p2.yml'))
     config['metrics']['output_imts'].append('Arias')
     config['metrics']['output_imcs'].append('arithmetic_mean')
     # turn off sta/lta check and snr checks
@@ -253,7 +258,7 @@ def test_metrics():
     datafiles, event = read_data_dir('knet', eventid, '*')
     datadir = os.path.split(datafiles[0])[0]
     raw_streams = StreamCollection.from_directory(datadir)
-    config = get_config()
+    config = update_config(os.path.join(datadir, 'config_min_freq_0p2.yml'))
     # turn off sta/lta check and snr checks
     # newconfig = drop_processing(config, ['check_sta_lta', 'compute_snr'])
     # processed_streams = process_streams(raw_streams, event, config=newconfig)
@@ -339,7 +344,7 @@ def test_vs30_dist_metrics():
     datafiles, event = read_data_dir('fdsn', eventid, '*')
     datadir = os.path.split(datafiles[0])[0]
     raw_streams = StreamCollection.from_directory(datadir)
-    config = get_config()
+    config = update_config(os.path.join(datadir, 'config_min_freq_0p2.yml'))
     processed_streams = process_streams(raw_streams, event, config=config)
     rupture_file = get_rupture_file(datadir)
     grid_file = os.path.join(datadir, 'test_grid.grd')

--- a/tests/gmprocess/processing_test.py
+++ b/tests/gmprocess/processing_test.py
@@ -14,9 +14,7 @@ from gmprocess.io.read import read_data
 from gmprocess.processing import process_streams
 from gmprocess.logging import setup_logger
 from gmprocess.io.test_utils import read_data_dir
-
-# homedir = os.path.dirname(os.path.abspath(__file__))
-# datadir = os.path.join(homedir, '..', 'data', 'testdata')
+from gmprocess.io.fetch_utils import update_config
 
 datapath = os.path.join('data', 'testdata')
 datadir = pkg_resources.resource_filename('gmprocess', datapath)
@@ -36,7 +34,9 @@ def test_process_streams():
 
     sc.describe()
 
-    test = process_streams(sc, origin)
+    config = update_config(os.path.join(datadir, 'config_min_freq_0p2.yml'))
+
+    test = process_streams(sc, origin, config=config)
 
     logging.info('Testing trace: %s' % test[0][1])
 


### PR DESCRIPTION
- Adds a new config option that allows the minimum frequency for SNR check to be a function of magnitude. This is now the new default. The minimum frequency scales with magnitude according to the attached figure. The ceiling and stress drop can be configured (defaults are 2.0 Hz and 10 bars).
- Removed a duplicate, unused function from `processing.py`
- Updated some tests that were dependent on the minimum frequency being set at 0.2 Hz to use a  dedicated config file.

![min_freq_vs_mag](https://user-images.githubusercontent.com/40367182/77967339-28066e80-72a2-11ea-854a-93b25594d70b.png)
