### PR TITLE
Minimum frequency floor

### DIFF
--- a/gmprocess/data/config.yml
+++ b/gmprocess/data/config.yml
@@ -216,8 +216,10 @@ processing:
                 stress_drop: 10  # bars
                 shear_vel: 3.7   # km/s
                 ceiling: 2.0     # Hz. If the computed f0 is greater than
-                # ceiling, than the ceiling frequency will be used. This should
+                # ceiling, then the ceiling frequency will be used. This should
                 # be less than max_freq.
+                floor: 0.1       # Hz. If the computed f0 is less than the
+                # floor, then the floor frequency will be used.
 
     # - NNet_QA:
     #     # Neural network quality assurance method by Bellagamba et al. (2019)

--- a/gmprocess/snr.py
+++ b/gmprocess/snr.py
@@ -114,7 +114,8 @@ def compute_snr(st, bandwidth, mag=None, check=None):
 
 
 def snr_check(tr, mag, threshold=3.0, min_freq='f0', max_freq=5.0, f0_options={
-              'stress_drop': 10, 'shear_vel': 3.7, 'ceiling': 2.0}):
+              'stress_drop': 10, 'shear_vel': 3.7, 'ceiling': 2.0,
+              'floor': 0.1}):
     """
     Check signal-to-noise ratio.
 
@@ -145,11 +146,13 @@ def snr_check(tr, mag, threshold=3.0, min_freq='f0', max_freq=5.0, f0_options={
 
         # If min_freq is 'f0', then compute Brune corner frequency
         if min_freq == 'f0':
-            min_freq = min(
-                brune_f0(
-                    moment_from_magnitude(mag), f0_options['stress_drop'],
-                    f0_options['shear_vel']),
-                f0_options['ceiling'])
+            min_freq = brune_f0(
+                moment_from_magnitude(mag), f0_options['stress_drop'],
+                f0_options['shear_vel'])
+            if min_freq < f0_options['floor']:
+                min_freq = f0_options['floor']
+            if min_freq > f0_options['ceiling']:
+                min_freq = f0_options['ceiling']
 
         # Check if signal criteria is met
         min_snr = np.min(snr[(freq >= min_freq) & (freq <= max_freq)])


### PR DESCRIPTION
Sets a minimum frequency floor option. Default is 0.1 Hz.
![min_freq_vs_mag_floor](https://user-images.githubusercontent.com/40367182/78699969-f4d76700-78c1-11ea-9995-35b5f6fc25d7.png)
