### PR TITLE
Map fix for stations close to event epicenter.

### DIFF
--- a/gmprocess/io/fetch_utils.py
+++ b/gmprocess/io/fetch_utils.py
@@ -173,8 +173,8 @@ def draw_stations_map(pstreams, event, event_dir):
     ymin = lats.min()
     ymax = lats.max()
 
-    diff_x = max(abs(cx - xmin), abs(cx - xmax))
-    diff_y = max(abs(cy - ymin), abs(cy - ymax))
+    diff_x = max(abs(cx - xmin), abs(cx - xmax), 1)
+    diff_y = max(abs(cy - ymin), abs(cy - ymax), 1)
 
     xmax = cx + MAP_PADDING * diff_x
     xmin = cx - MAP_PADDING * diff_x


### PR DESCRIPTION
Fixes an issue with the mapping code identified by Diego from University of Puerto Rico. For cases where the station locations are very close to the event location, the error AttributeError: 'list' object has no attribute 'xy'  was being generated. This fixes this by requiring a minimum value of the width and height for the map.