### PR TITLE
Fixing Raoof 99 attenuation function and adding spectral misfit metrics.

### DIFF
--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -122,6 +122,10 @@ FIT_SPECTRA_COLUMNS = {
     'stress_drop': 'Stress drop fit (bars)',
     'stress_drop_lnsd':
         'Natural log standard deviation of the stress drop fit',
+    'R2': (
+        'Coefficient of determination between fitted and observed spectra'),
+    'mean_squared_error': (
+        'Mean squared error between fitted and observed spectra')
 }
 
 
@@ -834,6 +838,9 @@ class StreamWorkspace(object):
             df = pd.DataFrame.from_dict(fit_table)
         else:
             df = pd.DataFrame(columns=FIT_SPECTRA_COLUMNS.keys())
+
+        # Ensure that the DataFrame columns are ordered correctly
+        df = df[FIT_SPECTRA_COLUMNS.keys()]
 
         readme = pd.DataFrame.from_dict(FIT_SPECTRA_COLUMNS, orient='index')
         readme.reset_index(level=0, inplace=True)

--- a/gmprocess/spectrum.py
+++ b/gmprocess/spectrum.py
@@ -156,6 +156,19 @@ def fit_spectra(st, origin, kappa=0.035,
             # stress_drop_lower = np.exp(result.x[1]-sd[1])
             # stress_drop_upper = np.exp(result.x[1]+sd[1])
 
+            # Get the fitted spectrum and then calculate the goodness-of-fit
+            # metrics
+            fit_spec = model(
+                (moment_fit, stress_drop_fit), freq, dist, kappa)
+            mean_squared_error = np.mean((obs_spec - fit_spec)**2)
+
+            # R^2 (Coefficient of Determination) is defined as 1 minus the
+            # residual sum of squares (SSR) divided by the total sum of squares
+            # (SST)
+            ssr = np.sum((obs_spec - fit_spec)**2)
+            sst = np.sum((obs_spec - np.mean(obs_spec))**2)
+            r_squared = 1 - (ssr / sst)
+
             fit_spectra_dict = {
                 'stress_drop': stress_drop_fit,
                 'stress_drop_lnsd': sd[1],
@@ -166,7 +179,9 @@ def fit_spectra(st, origin, kappa=0.035,
                 'magnitude': magnitude_fit,
                 'f0': f0_fit,
                 'minimize_message': result.message.decode(),
-                'minimize_success': result.success
+                'minimize_success': result.success,
+                'mean_squared_error': mean_squared_error,
+                'R2': r_squared
             }
             tr.setParameter('fit_spectra', fit_spectra_dict)
 
@@ -599,7 +614,7 @@ def geometrical_spreading(freq, dist, model="REA99"):
         if dist <= dist_cross:
             geom = dist**(-1.0)
         else:
-            geom = (dist / dist_cross)**(-0.5)
+            geom = (dist * dist_cross)**(-0.5)
     else:
         raise ValueError('Unsupported anelastic attenuation model.')
     return geom


### PR DESCRIPTION
 - Fixes an error in the Raoof 99 geometrical spreading attenuation equation.
- Adds two metrics for measuring the goodness-of-fit for the Brune spectral fitting: mean squared error and R^2. These will be saved in the fit_spectra_parameters.csv and README files.