### PR TITLE
Use both source & sender unless theyre the same

### DIFF
--- a/gmprocess/stationtrace.py
+++ b/gmprocess/stationtrace.py
@@ -658,7 +658,8 @@ class StationTrace(Trace):
 
 def _stats_from_inventory(data, inventory, channelid):
     if len(inventory.source):
-        if len(inventory.sender) and inventory.sender != inventory.source:
+        if (inventory.sender is not None and
+                inventory.sender != inventory.source):
             source = '%s,%s' % (inventory.source, inventory.sender)
         else:
             source = inventory.source

--- a/gmprocess/stationtrace.py
+++ b/gmprocess/stationtrace.py
@@ -658,7 +658,10 @@ class StationTrace(Trace):
 
 def _stats_from_inventory(data, inventory, channelid):
     if len(inventory.source):
-        source = inventory.source
+        if len(inventory.sender) and inventory.sender != inventory.source:
+            source = '%s,%s' % (inventory.source, inventory.sender)
+        else:
+            source = inventory.source
 
     # Due to pyasdf strict station merging criteria, we might actually have
     # to search for the correct station that contains the current channelid


### PR DESCRIPTION
`StationTrace.stats.standard.source` will now contain both the `Source` and `Sender` from the `StationXML` unless they are the same.