### PR TITLE
Fixed function to be found by tester.

### DIFF
--- a/tests/gmprocess/io/nsmn/turkey_fetcher_test.py
+++ b/tests/gmprocess/io/nsmn/turkey_fetcher_test.py
@@ -6,7 +6,7 @@ import os
 import logging
 
 
-def fetcher_test():
+def test_turkey_fetcher():
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
     # 2019-03-21 05:51:10
@@ -27,4 +27,4 @@ def fetcher_test():
 
 if __name__ == '__main__':
     os.environ['CALLED_FROM_PYTEST'] = 'True'
-    fetcher_test()
+    test_turkey_fetcher()


### PR DESCRIPTION
Fix the naming convention of the Turkey Fetcher test function so that it is found by `py.test`. There are other issues with the Turkey Fetcher that also need to be resolved.