### PR TITLE
Fixed: encoding on binary output.

### DIFF
--- a/gmprocess/io/cosmos/cesmd_search.py
+++ b/gmprocess/io/cosmos/cesmd_search.py
@@ -442,7 +442,7 @@ def get_records(output,
                 fin = myzip.open(member)
                 flatfile = member.replace('/', '_')
                 outfile = os.path.join(output, flatfile)
-                with open(outfile, 'wb', encoding='utf-8') as fout:
+                with open(outfile, 'wb') as fout:
                     fout.write(fin.read())
                 fin.close()
             else:
@@ -463,7 +463,7 @@ def get_records(output,
                             if not os.path.exists(datadir):
                                 os.makedirs(datadir)
                             outfile = os.path.join(datadir, flatfile)
-                            with open(outfile, 'wb', encoding='utf-8') as fout:
+                            with open(outfile, 'wb') as fout:
                                 fout.write(fin.read())
                             fin.close()
                     tmpzip.close()


### PR DESCRIPTION
The `encoding` keyword shouldn't be specified on binary files. This was causing an exception Python 3.7.