### PR TITLE
Update the metric controller to store peak value time

### DIFF
--- a/gmprocess/metrics/reduction/max.py
+++ b/gmprocess/metrics/reduction/max.py
@@ -38,10 +38,24 @@ class Max(Reduction):
             maximums: Dictionary of maximum value for each channel.
         """
         maximums = {}
+        times = {}
         if isinstance(self.reduction_data, (Stream, StationStream)):
             for trace in self.reduction_data:
-                maximums[trace.stats.channel] = np.abs(trace.max())
+                if trace.stats.standard.units == 'acc':
+                    key = 'pga_time'
+                elif trace.stats.standard.units == 'vel':
+                    key = 'pgv_time'
+                elif trace.stats.standard.units == 'disp':
+                    key = 'pgd_time'
+                else:
+                    key = 'peak_time'
+                idx = np.argmax(np.abs(trace.data))
+                max_value = np.abs(trace.data[idx])
+                max_time = trace.times(type='utcdatetime')[idx]
+                maximums[trace.stats.channel] = max_value
+                times[trace.stats.channel] = {key: max_time}
+            return maximums, times
         else:
             for chan in self.reduction_data:
                 maximums[chan] = np.abs(self.reduction_data[chan]).max()
-        return maximums
+            return maximums

--- a/gmprocess/metrics/transform/integrate.py
+++ b/gmprocess/metrics/transform/integrate.py
@@ -31,6 +31,9 @@ class Integrate(Transform):
         stream = StationStream([])
         for trace in self.transform_data:
             integrated_trace = trace.copy().integrate()
-            integrated_trace.stats['units'] = 'vel'
+            if integrated_trace.stats.standard.units == 'acc':
+                integrated_trace.stats.standard.units = 'vel'
+            elif integrated_trace.stats.standard.units == 'vel':
+                integrated_trace.stats.standard.units = 'disp'
             stream.append(integrated_trace)
         return stream

--- a/tests/gmprocess/metrics/peak_time_test.py
+++ b/tests/gmprocess/metrics/peak_time_test.py
@@ -1,0 +1,40 @@
+# third party imports
+from obspy.core.event import Origin
+from obspy.core.utcdatetime import UTCDateTime
+
+# local imports
+from gmprocess.io.geonet.core import read_geonet
+from gmprocess.io.read import read_data
+from gmprocess.io.test_utils import read_data_dir
+from gmprocess.metrics.reduction.max import Max
+from gmprocess.metrics.station_summary import StationSummary
+
+
+def test_get_peak_time():
+    datafiles, _ = read_data_dir(
+        'geonet', 'us1000778i', '20161113_110259_WTMC_20.V2A')
+    datafile = datafiles[0]
+    stream1 = read_geonet(datafile)[0]
+    max_cls = Max(stream1).result
+    assert len(max_cls) == 2
+
+    max_cls = Max({'chan': [0, 1, 2, 3]}).result
+    assert len(max_cls) == 1
+
+    stream2 = read_geonet(datafile)[0]
+    origin = Origin(latitude=42.6925, longitude=173.021944)
+    stream_summary = StationSummary.from_stream(
+        stream2,
+        ['channels'],
+        ['pgv', 'pga'], origin)
+    assert stream2[0].stats.pga_time == UTCDateTime('2016-11-13T11:03:08.880001Z')
+    assert stream2[0].stats.pgv_time == UTCDateTime('2016-11-13T11:03:10.580001Z')
+
+    assert stream2[1].stats.pga_time == UTCDateTime('2016-11-13T11:03:09.960001Z')
+    assert stream2[1].stats.pgv_time == UTCDateTime('2016-11-13T11:03:08.860001Z')
+
+    assert stream2[2].stats.pga_time == UTCDateTime('2016-11-13T11:03:08.140001Z')
+    assert stream2[2].stats.pgv_time == UTCDateTime('2016-11-13T11:03:09.560001Z')
+
+if __name__ == '__main__':
+    test_get_peak_time()


### PR DESCRIPTION
For any calculation of PGA, PGV, and PGD, the time corresponding to the peak value will be stored within the stats section of the traces. For example, if StationSummary.from_stream is used to get the IMTS, PGA and PGV, and the IMC, CHANNELS, then following the processing the stats "pga_time" and "pgv_time" will be in each trace within the stream. The time is obspy's UTCDatetime format.