### PR TITLE
Remove deletion of previously downloaded FDSN files

### DIFF
--- a/gmprocess/io/cosmos/cesmd_fetcher.py
+++ b/gmprocess/io/cosmos/cesmd_fetcher.py
@@ -7,7 +7,6 @@ import logging
 import pytz
 from obspy.core.utcdatetime import UTCDateTime
 import numpy as np
-from requests.exceptions import ConnectionError
 
 # local imports
 from gmprocess.io.fetcher import DataFetcher, _get_first_value

--- a/gmprocess/io/fetch_utils.py
+++ b/gmprocess/io/fetch_utils.py
@@ -46,10 +46,11 @@ FAILED_COLOR = '#ff2222'
 
 MAP_PADDING = 1.1  # Station map padding value
 
-UNITS = {'PGA': '%g',
-         'PGV': 'cm/s',
-         'SA': '%g'
-         }
+UNITS = {
+    'PGA': '%g',
+    'PGV': 'cm/s',
+    'SA': '%g'
+}
 
 FLOAT_PATTERN = r'[-+]?[0-9]*\.?[0-9]+'
 

--- a/gmprocess/io/nga.py
+++ b/gmprocess/io/nga.py
@@ -33,7 +33,7 @@ def get_nga_record_sequence_no(st, eq_name, distance_tolerance=50):
 
     Returns:
         int: Matching record sequence number from NGA flatfile. Returns
-            numpy.nan if record sequence number is not found.
+        numpy.nan if record sequence number is not found.
 
     """
 

--- a/gmprocess/io/obspy/fdsn_fetcher.py
+++ b/gmprocess/io/obspy/fdsn_fetcher.py
@@ -268,19 +268,6 @@ class FDSNFetcher(DataFetcher):
             # Pass off the initalized clients to the Mass Downloader
             mdl = MassDownloader(providers=client_list)
 
-            # we can have a problem of file overlap, so let's remove existing
-            # mseed files from the raw directory.
-            logging.info('Deleting old MiniSEED files...')
-            delete_old_files(rawdir, '*.mseed')
-
-            # remove existing png files as well
-            logging.info('Deleting old PNG files...')
-            delete_old_files(rawdir, '*.png')
-
-            # remove existing xml files as well
-            logging.info('Deleting old XML files...')
-            delete_old_files(rawdir, '*.xml')
-
             logging.info('Downloading new MiniSEED files...')
             # The data will be downloaded to the ``./waveforms/`` and
             # ``./stations/`` folders with automatically chosen file names.
@@ -304,9 +291,3 @@ class FDSNFetcher(DataFetcher):
             stream_collection = StreamCollection(
                 streams=streams, drop_non_free=self.drop_non_free)
             return stream_collection
-
-
-def delete_old_files(rawdir, pattern):
-    pfiles = glob.glob(os.path.join(rawdir, pattern))
-    for pfile in pfiles:
-        os.remove(pfile)


### PR DESCRIPTION
It is useful to re-run the download command and accumulate FDSN results because there are can be server/connection issues that cause data to be missed. 