### PR TITLE
Faster computation of trace times

### DIFF
--- a/gmprocess/io/fetch_utils.py
+++ b/gmprocess/io/fetch_utils.py
@@ -819,7 +819,9 @@ def get_station_feature(stream, metrics, coordinates,
 
     if expanded_imts:
         imts = list(
-            set([i[0] for i in metrics.pgms.index.to_numpy() if i[0].startswith('SA')]))
+            set([i[0] for i in metrics.pgms.index.to_numpy()
+                 if i[0].startswith('SA')])
+        )
         imt_lower = [s.lower() for s in imts]
         imt_units = [UNITS['SA']] * len(imts)
         if 'PGA' in metrics.pgms.index:

--- a/gmprocess/metrics/reduction/max.py
+++ b/gmprocess/metrics/reduction/max.py
@@ -56,8 +56,12 @@ class Max(Reduction):
                 else:
                     key = 'peak_time'
                 idx = np.argmax(np.abs(trace.data))
+                dtimes = np.linspace(
+                    0.0, trace.stats.endtime - trace.stats.starttime,
+                    trace.stats.npts)
+                dtime = dtimes[idx]
                 max_value = np.abs(trace.data[idx])
-                max_time = trace.times(type='utcdatetime')[idx]
+                max_time = trace.stats.starttime + dtime
                 maximums[trace.stats.channel] = max_value
                 times[trace.stats.channel] = {key: max_time}
             return maximums, times


### PR DESCRIPTION
This makes `compute_waveform_metrics` more than 5 times faster in my testing! :satisfied: