### PR TITLE
Two minor changes

### DIFF
--- a/gmprocess/io/global_fetcher.py
+++ b/gmprocess/io/global_fetcher.py
@@ -85,7 +85,7 @@ def fetch_data(time, lat, lon, depth, magnitude, config=None, rawdir=None,
     for fetcher in instances:
         if 'FDSN' in str(fetcher):
             tstreams = fetcher.retrieveData()
-            if len(streams):
+            if streams:
                 streams = streams + tstreams
             else:
                 streams = tstreams
@@ -97,7 +97,7 @@ def fetch_data(time, lat, lon, depth, magnitude, config=None, rawdir=None,
                 logging.warn(msg % (esummary, str(fetcher)))
                 continue
             tstreams = fetcher.retrieveData(events[0])
-            if len(streams):
+            if streams:
                 streams = streams + tstreams
             else:
                 streams = tstreams

--- a/gmprocess/io/report.py
+++ b/gmprocess/io/report.py
@@ -16,9 +16,13 @@ from impactutils.io.cmd import get_command_output
 from gmprocess.utils.config import get_config
 
 PREAMBLE = """
-\\documentclass[9pt]{article}
-\\usepackage{helvet}
-\\renewcommand{\\familydefault}{\\sfdefault}
+\\documentclass[9pt]{extarticle}
+
+% Allows for 9pt article class
+\\usepackage{extsizes}
+
+\\usepackage{sansmathfonts}
+\\usepackage[T1]{fontenc}
 
 \\usepackage{graphicx}
 \\usepackage{tikz}


### PR DESCRIPTION
Fixed testing of stream length. I was getting errors in some cases where streams got set to `None`. This test should work for both cases (zero length and `None` values).

The report used Helvetica font, which requires a pretty big (1 GB) font file on Ubuntu. I changed the font to be a standard sans serif font. The previous document class used 9pt, which isn't supported by the article class, but is supported by the extarticle class.