### PR TITLE
Make 'check_max_amplitude' option available on default config file.

### DIFF
--- a/gmprocess/data/config_production.yml
+++ b/gmprocess/data/config_production.yml
@@ -164,9 +164,9 @@ processing:
     # Amplitude check to avoid clipping. Units are usually counts (e.g., with
     # data from IRIS) but some sources will convert to physical units so it
     # is important to be careful with this step.
-    # - check_max_amplitude:
-    #     min: 5
-    #     max: 2e6
+    - check_max_amplitude:
+        min: 5
+        max: 2e6
 
     # Check number of traces for each instrument. Max is useful for screening
     # out downhole or structural arrays with the same station code.


### PR DESCRIPTION
Checking maximum amplitudes is not available under the default config. This could be useful to avoid clipping of certain stations. It does not show up in the default config because it is commented out.

Uncommenting the section in `config_production.yml` permits the section to show up in the default config file.