### PR TITLE
Save noise time series in ASDF

### DIFF
--- a/gmprocess/waveform_processing/processing.py
+++ b/gmprocess/waveform_processing/processing.py
@@ -261,7 +261,7 @@ def remove_response(st, f1, f2, f3=None, f4=None, water_level=None,
                 try:
                     tr.remove_response(
                         inventory=inv, output=output, water_level=water_level,
-                        pre_filt=(f1, f2, f3, f4))
+                        pre_filt=(f1, f2, f3, f4), zero_mean=True, taper=False)
                     tr.stats.standard.units = output.lower()
                     tr.stats.standard.process_level = PROCESS_LEVELS['V1']
                 except BaseException as e:
@@ -307,7 +307,8 @@ def remove_response(st, f1, f2, f3=None, f4=None, water_level=None,
                     else:
                         tr.remove_response(
                             inventory=inv, output=output,
-                            water_level=water_level
+                            water_level=water_level,
+                            zero_mean=True, taper=False
                         )
                         tr.data *= M_TO_CM  # Convert from m to cm
                         tr.stats.standard.units = output.lower()

--- a/gmprocess/waveform_processing/snr.py
+++ b/gmprocess/waveform_processing/snr.py
@@ -26,6 +26,13 @@ def compute_snr_trace(tr, bandwidth, mag=None, check=None):
         noise = tr.copy().trim(endtime=split_time)
         signal = tr.copy().trim(starttime=split_time)
 
+        tr.setCached(
+            'noise_trace', {
+                'times': noise.times(),
+                'data': noise.data
+            }
+        )
+
         noise.detrend('demean')
         signal.detrend('demean')
 

--- a/tests/gmprocess/io/obspy/obspy_test.py
+++ b/tests/gmprocess/io/obspy/obspy_test.py
@@ -136,7 +136,7 @@ def test_weird_sensitivity():
     sc = StreamCollection(streams)
     psc = process_streams(sc, origin)
     channel = psc[0].select(component='E')[0]
-    assert_almost_equal(channel.data.max(), 62900.191900393373)
+    assert_almost_equal(channel.data.max(), 62900.195313894299)
 
 
 def test():


### PR DESCRIPTION
Store noise time series in ASDF and removed extra taper in the obspy remove_response method