### PR TITLE
Sanity

### DIFF
--- a/gmprocess/apps/gmrecords.py
+++ b/gmprocess/apps/gmrecords.py
@@ -170,7 +170,7 @@ class GMrecordsApp(object):
             version='%(prog)s ' + __version__,
             help='Print program version.')
         self.parser.add_argument(
-            '--log', action='store_true', default=False,
+            '-l', '--log', action='store_true', default=False,
             help='Log all output to a file in the project data directory.')
 
         # Parsers for subcommands

--- a/gmprocess/core/stationtrace.py
+++ b/gmprocess/core/stationtrace.py
@@ -441,8 +441,8 @@ class StationTrace(Trace):
             'module': calling_module,
             'reason': reason
         })
-        logging.info(calling_module)
-        logging.info(reason)
+        trace_id = "%s" % self.id
+        logging.info('%s - %s - %s' % (calling_module, trace_id, reason))
 
     def validate(self):
         """Ensure that all required metadata fields have been set.

--- a/gmprocess/data/config_production.yml
+++ b/gmprocess/data/config_production.yml
@@ -185,8 +185,10 @@ processing:
         threshold: 0.2
 
     - detrend:
-        # Supported obspy methods (besides the baseline described below):
+        # Supported obspy methods:
         #     constant, demean, linear, polynomial, simple, spline
+        # Also:
+        #     baseline_sixth_order, pre
         detrending_method: demean
 
     - check_zero_crossings:
@@ -216,13 +218,9 @@ processing:
         water_level: 60
 
     - detrend:
-        # Supported obspy methods (besides the baseline described below):
-        #     constant, demean, linear, polynomial, simple, spline
         detrending_method: linear
 
     - detrend:
-        # Supported obspy methods (besides the baseline described below):
-        #     constant, demean, linear, polynomial, simple, spline
         detrending_method: demean
 
     - compute_snr:
@@ -338,13 +336,15 @@ processing:
         # determined with 'corner_frequencies' section.
         filter_order: 5
         number_of_passes: 2
+    - detrend:    
+        detrending_method: pre
 
-    # - detrend:
+    - detrend:
     #     # The current baseline correction method fits a sixth-order polynomial
     #     # to the displacement time series, and sets the zeroth- and first-order
     #     # terms to be zero. The second derivative of the fit polynomial is then
     #     # removed from the acceleration time series.
-    #     detrending_method: baseline_sixth_order
+        detrending_method: baseline_sixth_order
 
     # - trim_multiple_events:
     #     pga_factor: 0.2
@@ -398,9 +398,9 @@ processing:
     - check_tail:
         # Tail duration in sec
         duration: 5.0
-        # Max ratio of of the absolute velocity in the tail to the full trace.
-        max_vel_ratio: 0.1
-        # Max ratio of of the absolute displacement in the tail to the full 
+        # Max ratio of the absolute velocity in the tail to the full trace.
+        max_vel_ratio: 0.25
+        # Max ratio of the absolute displacement in the tail to the full 
         # trace.
         max_dis_ratio: 0.5
 

--- a/gmprocess/data/config_production.yml
+++ b/gmprocess/data/config_production.yml
@@ -140,7 +140,7 @@ windows:
         model: AS16
         # Number of standard deviations; if epsilon is 1.0, then the signal
         # window duration is the mean Ds + 1 standard deviation.
-        epsilon: 2.0
+        epsilon: 3.0
 
     window_checks:
         # Minimum noise duration; can be zero but this will allow for errors
@@ -310,13 +310,14 @@ processing:
     #       a: 50
 
     - cut:
-        # No required options; the presence of this key just indicates when to
+        # No required options; the presence of this step just indicates when to
         # cut the time series using the record start and signal end that were
         # configured in the windows section.
 
-        # Optionally, can specify how many seconds to include prior to the
-        # split between the noise and signal windows. If set to "Null" then
-        # the beginning of the record will be unchanged.
+        # Optionally, can specify 'sec_before_split' which shifts the start
+        # time of the signal window (relative to the estimated p-wave arrival). 
+        # If set to "Null" then the beginning of the signal window will be
+        # unchanged.
         sec_before_split: 2.0
 
     - taper:
@@ -399,10 +400,10 @@ processing:
         # Tail duration in sec
         duration: 5.0
         # Max ratio of the absolute velocity in the tail to the full trace.
-        max_vel_ratio: 0.25
+        max_vel_ratio: 0.3
         # Max ratio of the absolute displacement in the tail to the full 
         # trace.
-        max_dis_ratio: 0.5
+        max_dis_ratio: 0.6
 
 colocated:
     # This section is for handling colocated instruments that have otherwise

--- a/gmprocess/data/config_production.yml
+++ b/gmprocess/data/config_production.yml
@@ -395,6 +395,15 @@ processing:
         # Max stress for fit search (bars)
         max_stress: 10000
 
+    - check_tail:
+        # Tail duration in sec
+        duration: 5.0
+        # Max ratio of of the absolute velocity in the tail to the full trace.
+        max_vel_ratio: 0.1
+        # Max ratio of of the absolute displacement in the tail to the full 
+        # trace.
+        max_dis_ratio: 0.5
+
 colocated:
     # This section is for handling colocated instruments that have otherwise
     # passed tests. For reference:

--- a/gmprocess/data/testdata/asdf/asdf_layout.txt
+++ b/gmprocess/data/testdata/asdf/asdf_layout.txt
@@ -1,203 +1,230 @@
-dataset    /QuakeML
-group      /Waveforms
-group      /Waveforms/NZ.HSES
-dataset    /Waveforms/NZ.HSES/NZ.HSES.--.HN1__2016-11-13T11:02:20__2016-11-13T11:07:47__us1000778i_unprocessed
-dataset    /Waveforms/NZ.HSES/NZ.HSES.--.HN1__2016-11-13T11:03:00__2016-11-13T11:05:11__us1000778i_ptest
-dataset    /Waveforms/NZ.HSES/NZ.HSES.--.HN2__2016-11-13T11:02:20__2016-11-13T11:07:47__us1000778i_unprocessed
-dataset    /Waveforms/NZ.HSES/NZ.HSES.--.HN2__2016-11-13T11:03:00__2016-11-13T11:05:11__us1000778i_ptest
-dataset    /Waveforms/NZ.HSES/NZ.HSES.--.HNZ__2016-11-13T11:02:20__2016-11-13T11:07:47__us1000778i_unprocessed
-dataset    /Waveforms/NZ.HSES/NZ.HSES.--.HNZ__2016-11-13T11:03:00__2016-11-13T11:05:11__us1000778i_ptest
-dataset    /Waveforms/NZ.HSES/StationXML
-group      /Waveforms/NZ.THZ
-dataset    /Waveforms/NZ.THZ/NZ.THZ.--.HN1__2016-11-13T11:02:33__2016-11-13T11:07:28__us1000778i_unprocessed
-dataset    /Waveforms/NZ.THZ/NZ.THZ.--.HN1__2016-11-13T11:03:13__2016-11-13T11:05:50__us1000778i_ptest
-dataset    /Waveforms/NZ.THZ/NZ.THZ.--.HN2__2016-11-13T11:02:33__2016-11-13T11:07:28__us1000778i_unprocessed
-dataset    /Waveforms/NZ.THZ/NZ.THZ.--.HN2__2016-11-13T11:03:13__2016-11-13T11:05:50__us1000778i_ptest
-dataset    /Waveforms/NZ.THZ/NZ.THZ.--.HNZ__2016-11-13T11:02:33__2016-11-13T11:07:28__us1000778i_unprocessed
-dataset    /Waveforms/NZ.THZ/NZ.THZ.--.HNZ__2016-11-13T11:03:13__2016-11-13T11:05:50__us1000778i_ptest
-dataset    /Waveforms/NZ.THZ/StationXML
-group      /Waveforms/NZ.WTMC
-dataset    /Waveforms/NZ.WTMC/NZ.WTMC.--.HN1__2016-11-13T11:02:19__2016-11-13T11:07:46__us1000778i_unprocessed
-dataset    /Waveforms/NZ.WTMC/NZ.WTMC.--.HN1__2016-11-13T11:02:57__2016-11-13T11:04:58__us1000778i_ptest
-dataset    /Waveforms/NZ.WTMC/NZ.WTMC.--.HN2__2016-11-13T11:02:19__2016-11-13T11:07:46__us1000778i_unprocessed
-dataset    /Waveforms/NZ.WTMC/NZ.WTMC.--.HN2__2016-11-13T11:02:57__2016-11-13T11:04:58__us1000778i_ptest
-dataset    /Waveforms/NZ.WTMC/NZ.WTMC.--.HNZ__2016-11-13T11:02:19__2016-11-13T11:07:46__us1000778i_unprocessed
-dataset    /Waveforms/NZ.WTMC/NZ.WTMC.--.HNZ__2016-11-13T11:02:57__2016-11-13T11:04:58__us1000778i_ptest
-dataset    /Waveforms/NZ.WTMC/StationXML
-group      /AuxiliaryData
-group      /AuxiliaryData/Cache/NoiseSpectrumFreq
-group      /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.HSES
-dataset    /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.THZ
-dataset    /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.WTMC
-dataset    /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/NoiseSpectrumSpec
-group      /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.HSES
-dataset    /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.THZ
-dataset    /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.WTMC
-dataset    /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SignalSpectrumFreq
-group      /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.HSES
-dataset    /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.THZ
-dataset    /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.WTMC
-dataset    /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SignalSpectrumSpec
-group      /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.HSES
-dataset    /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.THZ
-dataset    /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.WTMC
-dataset    /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq
-group      /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.HSES
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.THZ
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.WTMC
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec
-group      /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.HSES
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.THZ
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.WTMC
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothSignalSpectrumFreq
-group      /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.HSES
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.THZ
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.WTMC
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothSignalSpectrumSpec
-group      /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.HSES
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.THZ
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.WTMC
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SnrFreq
-group      /AuxiliaryData/Cache/SnrFreq/NZ.HSES
-dataset    /AuxiliaryData/Cache/SnrFreq/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrFreq/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrFreq/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SnrFreq/NZ.THZ
-dataset    /AuxiliaryData/Cache/SnrFreq/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrFreq/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrFreq/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SnrFreq/NZ.WTMC
-dataset    /AuxiliaryData/Cache/SnrFreq/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrFreq/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrFreq/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SnrSnr
-group      /AuxiliaryData/Cache/SnrSnr/NZ.HSES
-dataset    /AuxiliaryData/Cache/SnrSnr/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrSnr/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrSnr/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SnrSnr/NZ.THZ
-dataset    /AuxiliaryData/Cache/SnrSnr/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrSnr/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrSnr/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/Cache/SnrSnr/NZ.WTMC
-dataset    /AuxiliaryData/Cache/SnrSnr/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrSnr/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/Cache/SnrSnr/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/StationMetrics
-group      /AuxiliaryData/StationMetrics/NZ.HSES
-dataset    /AuxiliaryData/StationMetrics/NZ.HSES/NZ.HSES.--.HN_us1000778i
-group      /AuxiliaryData/StationMetrics/NZ.THZ
-dataset    /AuxiliaryData/StationMetrics/NZ.THZ/NZ.THZ.--.HN_us1000778i
-group      /AuxiliaryData/StationMetrics/NZ.WTMC
-dataset    /AuxiliaryData/StationMetrics/NZ.WTMC/NZ.WTMC.--.HN_us1000778i
-group      /AuxiliaryData/TraceProcessingParameters
-group      /AuxiliaryData/TraceProcessingParameters/NZ.HSES
-dataset    /AuxiliaryData/TraceProcessingParameters/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/TraceProcessingParameters/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/TraceProcessingParameters/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/TraceProcessingParameters/NZ.THZ
-dataset    /AuxiliaryData/TraceProcessingParameters/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/TraceProcessingParameters/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/TraceProcessingParameters/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/TraceProcessingParameters/NZ.WTMC
-dataset    /AuxiliaryData/TraceProcessingParameters/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /AuxiliaryData/TraceProcessingParameters/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /AuxiliaryData/TraceProcessingParameters/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
-group      /AuxiliaryData/WaveFormMetrics
-group      /AuxiliaryData/WaveFormMetrics/NZ.HSES
-dataset    /AuxiliaryData/WaveFormMetrics/NZ.HSES/NZ.HSES.--.HN_us1000778i_ptest
-group      /AuxiliaryData/WaveFormMetrics/NZ.THZ
-dataset    /AuxiliaryData/WaveFormMetrics/NZ.THZ/NZ.THZ.--.HN_us1000778i_ptest
-group      /AuxiliaryData/WaveFormMetrics/NZ.WTMC
-dataset    /AuxiliaryData/WaveFormMetrics/NZ.WTMC/NZ.WTMC.--.HN_us1000778i_ptest
-group      /Provenance
-dataset    /Provenance/NZ.HSES.--.HN1_us1000778i_ptest
-dataset    /Provenance/NZ.HSES.--.HN1_us1000778i_unprocessed
-dataset    /Provenance/NZ.HSES.--.HN2_us1000778i_ptest
-dataset    /Provenance/NZ.HSES.--.HN2_us1000778i_unprocessed
-dataset    /Provenance/NZ.HSES.--.HNZ_us1000778i_ptest
-dataset    /Provenance/NZ.HSES.--.HNZ_us1000778i_unprocessed
-dataset    /Provenance/NZ.THZ.--.HN1_us1000778i_ptest
-dataset    /Provenance/NZ.THZ.--.HN1_us1000778i_unprocessed
-dataset    /Provenance/NZ.THZ.--.HN2_us1000778i_ptest
-dataset    /Provenance/NZ.THZ.--.HN2_us1000778i_unprocessed
-dataset    /Provenance/NZ.THZ.--.HNZ_us1000778i_ptest
-dataset    /Provenance/NZ.THZ.--.HNZ_us1000778i_unprocessed
-dataset    /Provenance/NZ.WTMC.--.HN1_us1000778i_ptest
-dataset    /Provenance/NZ.WTMC.--.HN1_us1000778i_unprocessed
-dataset    /Provenance/NZ.WTMC.--.HN2_us1000778i_ptest
-dataset    /Provenance/NZ.WTMC.--.HN2_us1000778i_unprocessed
-dataset    /Provenance/NZ.WTMC.--.HNZ_us1000778i_ptest
-dataset    /Provenance/NZ.WTMC.--.HNZ_us1000778i_unprocessed
+AuxiliaryData
+AuxiliaryData/Cache
+AuxiliaryData/Cache/NoiseSpectrumFreq
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.HSES
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.THZ
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.WTMC
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumSpec
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.HSES
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.THZ
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.WTMC
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceData
+AuxiliaryData/Cache/NoiseTraceData/NZ.HSES
+AuxiliaryData/Cache/NoiseTraceData/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceData/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceData/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceData/NZ.THZ
+AuxiliaryData/Cache/NoiseTraceData/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceData/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceData/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceData/NZ.WTMC
+AuxiliaryData/Cache/NoiseTraceData/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceData/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceData/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceTimes
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.HSES
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.THZ
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.WTMC
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/NoiseTraceTimes/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumFreq
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.HSES
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.THZ
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.WTMC
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumSpec
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.HSES
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.THZ
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.WTMC
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.HSES
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.THZ
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.WTMC
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.HSES
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.THZ
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.WTMC
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothNoiseSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.HSES
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.THZ
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.WTMC
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumFreq/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.HSES
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.THZ
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.WTMC
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SmoothSignalSpectrumSpec/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SnrFreq
+AuxiliaryData/Cache/SnrFreq/NZ.HSES
+AuxiliaryData/Cache/SnrFreq/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SnrFreq/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SnrFreq/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SnrFreq/NZ.THZ
+AuxiliaryData/Cache/SnrFreq/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SnrFreq/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SnrFreq/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SnrFreq/NZ.WTMC
+AuxiliaryData/Cache/SnrFreq/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SnrFreq/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SnrFreq/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SnrSnr
+AuxiliaryData/Cache/SnrSnr/NZ.HSES
+AuxiliaryData/Cache/SnrSnr/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SnrSnr/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SnrSnr/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SnrSnr/NZ.THZ
+AuxiliaryData/Cache/SnrSnr/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SnrSnr/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SnrSnr/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/Cache/SnrSnr/NZ.WTMC
+AuxiliaryData/Cache/SnrSnr/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/Cache/SnrSnr/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/Cache/SnrSnr/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/StationMetrics
+AuxiliaryData/StationMetrics/NZ.HSES
+AuxiliaryData/StationMetrics/NZ.HSES/NZ.HSES.--.HN_us1000778i
+AuxiliaryData/StationMetrics/NZ.THZ
+AuxiliaryData/StationMetrics/NZ.THZ/NZ.THZ.--.HN_us1000778i
+AuxiliaryData/StationMetrics/NZ.WTMC
+AuxiliaryData/StationMetrics/NZ.WTMC/NZ.WTMC.--.HN_us1000778i
+AuxiliaryData/TraceProcessingParameters
+AuxiliaryData/TraceProcessingParameters/NZ.HSES
+AuxiliaryData/TraceProcessingParameters/NZ.HSES/NZ.HSES.--.HN1_us1000778i_ptest
+AuxiliaryData/TraceProcessingParameters/NZ.HSES/NZ.HSES.--.HN2_us1000778i_ptest
+AuxiliaryData/TraceProcessingParameters/NZ.HSES/NZ.HSES.--.HNZ_us1000778i_ptest
+AuxiliaryData/TraceProcessingParameters/NZ.THZ
+AuxiliaryData/TraceProcessingParameters/NZ.THZ/NZ.THZ.--.HN1_us1000778i_ptest
+AuxiliaryData/TraceProcessingParameters/NZ.THZ/NZ.THZ.--.HN2_us1000778i_ptest
+AuxiliaryData/TraceProcessingParameters/NZ.THZ/NZ.THZ.--.HNZ_us1000778i_ptest
+AuxiliaryData/TraceProcessingParameters/NZ.WTMC
+AuxiliaryData/TraceProcessingParameters/NZ.WTMC/NZ.WTMC.--.HN1_us1000778i_ptest
+AuxiliaryData/TraceProcessingParameters/NZ.WTMC/NZ.WTMC.--.HN2_us1000778i_ptest
+AuxiliaryData/TraceProcessingParameters/NZ.WTMC/NZ.WTMC.--.HNZ_us1000778i_ptest
+AuxiliaryData/WaveFormMetrics
+AuxiliaryData/WaveFormMetrics/NZ.HSES
+AuxiliaryData/WaveFormMetrics/NZ.HSES/NZ.HSES.--.HN_us1000778i_ptest
+AuxiliaryData/WaveFormMetrics/NZ.THZ
+AuxiliaryData/WaveFormMetrics/NZ.THZ/NZ.THZ.--.HN_us1000778i_ptest
+AuxiliaryData/WaveFormMetrics/NZ.WTMC
+AuxiliaryData/WaveFormMetrics/NZ.WTMC/NZ.WTMC.--.HN_us1000778i_ptest
+Provenance
+Provenance/NZ.HSES.--.HN1_us1000778i_ptest
+Provenance/NZ.HSES.--.HN1_us1000778i_unprocessed
+Provenance/NZ.HSES.--.HN2_us1000778i_ptest
+Provenance/NZ.HSES.--.HN2_us1000778i_unprocessed
+Provenance/NZ.HSES.--.HNZ_us1000778i_ptest
+Provenance/NZ.HSES.--.HNZ_us1000778i_unprocessed
+Provenance/NZ.THZ.--.HN1_us1000778i_ptest
+Provenance/NZ.THZ.--.HN1_us1000778i_unprocessed
+Provenance/NZ.THZ.--.HN2_us1000778i_ptest
+Provenance/NZ.THZ.--.HN2_us1000778i_unprocessed
+Provenance/NZ.THZ.--.HNZ_us1000778i_ptest
+Provenance/NZ.THZ.--.HNZ_us1000778i_unprocessed
+Provenance/NZ.WTMC.--.HN1_us1000778i_ptest
+Provenance/NZ.WTMC.--.HN1_us1000778i_unprocessed
+Provenance/NZ.WTMC.--.HN2_us1000778i_ptest
+Provenance/NZ.WTMC.--.HN2_us1000778i_unprocessed
+Provenance/NZ.WTMC.--.HNZ_us1000778i_ptest
+Provenance/NZ.WTMC.--.HNZ_us1000778i_unprocessed
+QuakeML
+Waveforms
+Waveforms/NZ.HSES
+Waveforms/NZ.HSES/NZ.HSES.--.HN1__2016-11-13T11:02:20__2016-11-13T11:07:47__us1000778i_unprocessed
+Waveforms/NZ.HSES/NZ.HSES.--.HN1__2016-11-13T11:03:00__2016-11-13T11:05:24__us1000778i_ptest
+Waveforms/NZ.HSES/NZ.HSES.--.HN2__2016-11-13T11:02:20__2016-11-13T11:07:47__us1000778i_unprocessed
+Waveforms/NZ.HSES/NZ.HSES.--.HN2__2016-11-13T11:03:00__2016-11-13T11:05:24__us1000778i_ptest
+Waveforms/NZ.HSES/NZ.HSES.--.HNZ__2016-11-13T11:02:20__2016-11-13T11:07:47__us1000778i_unprocessed
+Waveforms/NZ.HSES/NZ.HSES.--.HNZ__2016-11-13T11:03:00__2016-11-13T11:05:24__us1000778i_ptest
+Waveforms/NZ.HSES/StationXML
+Waveforms/NZ.THZ
+Waveforms/NZ.THZ/NZ.THZ.--.HN1__2016-11-13T11:02:33__2016-11-13T11:07:28__us1000778i_unprocessed
+Waveforms/NZ.THZ/NZ.THZ.--.HN1__2016-11-13T11:03:13__2016-11-13T11:06:06__us1000778i_ptest
+Waveforms/NZ.THZ/NZ.THZ.--.HN2__2016-11-13T11:02:33__2016-11-13T11:07:28__us1000778i_unprocessed
+Waveforms/NZ.THZ/NZ.THZ.--.HN2__2016-11-13T11:03:13__2016-11-13T11:06:06__us1000778i_ptest
+Waveforms/NZ.THZ/NZ.THZ.--.HNZ__2016-11-13T11:02:33__2016-11-13T11:07:28__us1000778i_unprocessed
+Waveforms/NZ.THZ/NZ.THZ.--.HNZ__2016-11-13T11:03:13__2016-11-13T11:06:06__us1000778i_ptest
+Waveforms/NZ.THZ/StationXML
+Waveforms/NZ.WTMC
+Waveforms/NZ.WTMC/NZ.WTMC.--.HN1__2016-11-13T11:02:19__2016-11-13T11:07:46__us1000778i_unprocessed
+Waveforms/NZ.WTMC/NZ.WTMC.--.HN1__2016-11-13T11:02:57__2016-11-13T11:05:10__us1000778i_ptest
+Waveforms/NZ.WTMC/NZ.WTMC.--.HN2__2016-11-13T11:02:19__2016-11-13T11:07:46__us1000778i_unprocessed
+Waveforms/NZ.WTMC/NZ.WTMC.--.HN2__2016-11-13T11:02:57__2016-11-13T11:05:10__us1000778i_ptest
+Waveforms/NZ.WTMC/NZ.WTMC.--.HNZ__2016-11-13T11:02:19__2016-11-13T11:07:46__us1000778i_unprocessed
+Waveforms/NZ.WTMC/NZ.WTMC.--.HNZ__2016-11-13T11:02:57__2016-11-13T11:05:10__us1000778i_ptest
+Waveforms/NZ.WTMC/StationXML

--- a/gmprocess/subcommands/arg_dicts.py
+++ b/gmprocess/subcommands/arg_dicts.py
@@ -7,7 +7,7 @@ ARG_DICTS = {
         'long_flag': '--label',
         'help': ('Processing label. If None (default) then we will disregard '
                  'the unprocessed label, and if there is only one remaining '
-                 'label then we will it. If there are multiple remaining '
+                 'label then we will use it. If there are multiple remaining '
                  'labels then we will prmpt you to select one.'),
         'type': str,
         'default': None,

--- a/gmprocess/subcommands/process_waveforms.py
+++ b/gmprocess/subcommands/process_waveforms.py
@@ -30,7 +30,7 @@ class ProcessWaveformsModule(SubcommandModule):
             'short_flag': '-l',
             'long_flag': '--label',
             'help': ('Processing label (single word, no spaces) to attach to '
-                     'processed files. Defaults label is \'default\'.'),
+                     'processed files. Default label is \'default\'.'),
             'type': str,
             'default': None,
         },

--- a/gmprocess/utils/plot.py
+++ b/gmprocess/utils/plot.py
@@ -518,10 +518,10 @@ def summary_plots(st, directory, origin):
         os.makedirs(directory)
 
     # Setup figure for stream
-    nrows = 4
+    nrows = 5
     ntrace = min(len(st), 3)
     fig = plt.figure(figsize=(3.9 * ntrace, 10))
-    gs = fig.add_gridspec(nrows, ntrace, height_ratios=[1, 1, 2, 2])
+    gs = fig.add_gridspec(nrows, ntrace, height_ratios=[1, 1, 1, 2, 2])
     ax = [plt.subplot(g) for g in gs]
 
     stream_id = st.get_id()
@@ -539,6 +539,10 @@ def summary_plots(st, directory, origin):
     # Compute velocity
     st_vel = st.copy()
     st_vel = st_vel.integrate()
+
+    # Compute displacement
+    st_dis = st_vel.copy()
+    st_dis = st_dis.integrate()
 
     # process channels in preferred sort order (i.e., HN1, HN2, HNZ)
     channels = [tr.stats.channel for tr in st]
@@ -650,48 +654,72 @@ def summary_plots(st, directory, origin):
         ax[j + ntrace].set_ylabel('Velocity (cm/s)')
 
         # ---------------------------------------------------------------------
+        # Displacement time series plot
+        tr_dis = st_dis[j]
+        dtimes = np.linspace(
+            0, tr_dis.stats.endtime - tr_dis.stats.starttime, tr_dis.stats.npts
+        )
+        ax[j + 2 * ntrace].plot(dtimes, tr_dis.data, 'k', linewidth=0.5)
+
+        # Show signal split as vertical dashed line
+        if tr.hasParameter('signal_split'):
+            split_dict = tr.getParameter('signal_split')
+            sptime = UTCDateTime(split_dict['split_time'])
+            dsec = sptime - tr.stats.starttime
+            ax[j + 2 * ntrace].axvline(dsec, color='red', linestyle='dashed')
+
+        ax[j + 2 * ntrace].set_xlabel('Time (s)')
+        ax[j + 2 * ntrace].set_ylabel('Displacement (cm)')
+
+        # ---------------------------------------------------------------------
         # Spectral plot
 
         # Raw signal spec
         if signal_dict is not None:
-            ax[j + 2 * ntrace].loglog(signal_dict['freq'],
-                                      signal_dict['spec'],
-                                      color='lightblue')
+            ax[j + 3 * ntrace].loglog(
+                signal_dict['freq'],
+                signal_dict['spec'],
+                color='lightblue')
 
         # Smoothed signal spec
         if smooth_signal_dict is not None:
-            ax[j + 2 * ntrace].loglog(smooth_signal_dict['freq'],
-                                      smooth_signal_dict['spec'],
-                                      color='blue',
-                                      label='Signal')
+            ax[j + 3 * ntrace].loglog(
+                smooth_signal_dict['freq'],
+                smooth_signal_dict['spec'],
+                color='blue',
+                label='Signal')
 
         # Raw noise spec
         if noise_dict is not None:
-            ax[j + 2 * ntrace].loglog(noise_dict['freq'],
-                                      noise_dict['spec'],
-                                      color='salmon')
+            ax[j + 3 * ntrace].loglog(
+                noise_dict['freq'],
+                noise_dict['spec'],
+                color='salmon')
 
         # Smoothed noise spec
         if smooth_noise_dict is not None:
-            ax[j + 2 * ntrace].loglog(smooth_noise_dict['freq'],
-                                      smooth_noise_dict['spec'],
-                                      color='red',
-                                      label='Noise')
+            ax[j + 3 * ntrace].loglog(
+                smooth_noise_dict['freq'],
+                smooth_noise_dict['spec'],
+                color='red',
+                label='Noise')
 
         if fit_spectra_dict is not None:
             # Model spec
-            ax[j + 2 * ntrace].loglog(smooth_signal_dict['freq'],
-                                      model_spec,
-                                      color='black',
-                                      linestyle='dashed')
+            ax[j + 3 * ntrace].loglog(
+                smooth_signal_dict['freq'],
+                model_spec,
+                color='black',
+                linestyle='dashed')
 
             # Corner frequency
-            ax[j + 2 * ntrace].axvline(fit_spectra_dict['f0'],
-                                       color='black',
-                                       linestyle='dashed')
+            ax[j + 3 * ntrace].axvline(
+                fit_spectra_dict['f0'],
+                color='black',
+                linestyle='dashed')
 
-        ax[j + 2 * ntrace].set_xlabel('Frequency (Hz)')
-        ax[j + 2 * ntrace].set_ylabel('Amplitude (cm/s)')
+        ax[j + 3 * ntrace].set_xlabel('Frequency (Hz)')
+        ax[j + 3 * ntrace].set_ylabel('Amplitude (cm/s)')
 
         # ---------------------------------------------------------------------
         # Signal-to-noise ratio plot
@@ -699,36 +727,42 @@ def summary_plots(st, directory, origin):
         if 'corner_frequencies' in tr.getParameterKeys():
             hp = tr.getParameter('corner_frequencies')['highpass']
             lp = tr.getParameter('corner_frequencies')['lowpass']
-            ax[j + 3 * ntrace].axvline(hp,
-                                       color='black',
-                                       linestyle='--',
-                                       label='Highpass')
-            ax[j + 3 * ntrace].axvline(lp,
-                                       color='black',
-                                       linestyle='--',
-                                       label='Lowpass')
+            ax[j + 4 * ntrace].axvline(
+                hp,
+                color='black',
+                linestyle='--',
+                label='Highpass')
+            ax[j + 4 * ntrace].axvline(
+                lp,
+                color='black',
+                linestyle='--',
+                label='Lowpass')
 
         if snr_conf is not None:
-            ax[j + 3 * ntrace].axhline(snr_conf['threshold'],
-                                       color='0.75',
-                                       linestyle='-',
-                                       linewidth=2)
-            ax[j + 3 * ntrace].axvline(snr_conf['max_freq'],
-                                       color='0.75',
-                                       linewidth=2,
-                                       linestyle='-')
-            ax[j + 3 * ntrace].axvline(snr_conf['min_freq'],
-                                       color='0.75',
-                                       linewidth=2,
-                                       linestyle='-')
+            ax[j + 4 * ntrace].axhline(
+                snr_conf['threshold'],
+                color='0.75',
+                linestyle='-',
+                linewidth=2)
+            ax[j + 4 * ntrace].axvline(
+                snr_conf['max_freq'],
+                color='0.75',
+                linewidth=2,
+                linestyle='-')
+            ax[j + 4 * ntrace].axvline(
+                snr_conf['min_freq'],
+                color='0.75',
+                linewidth=2,
+                linestyle='-')
 
         if snr_dict is not None:
-            ax[j + 3 * ntrace].loglog(snr_dict['freq'],
-                                      snr_dict['snr'],
-                                      label='SNR')
+            ax[j + 4 * ntrace].loglog(
+                snr_dict['freq'],
+                snr_dict['snr'],
+                label='SNR')
 
-        ax[j + 3 * ntrace].set_ylabel('SNR')
-        ax[j + 3 * ntrace].set_xlabel('Frequency (Hz)')
+        ax[j + 4 * ntrace].set_ylabel('SNR')
+        ax[j + 4 * ntrace].set_xlabel('Frequency (Hz)')
 
     stream_id = st.get_id()
 

--- a/gmprocess/waveform_processing/processing.py
+++ b/gmprocess/waveform_processing/processing.py
@@ -650,6 +650,13 @@ def _detrend_pre_event_mean(trace):
     Returns:
         trace: Detrended trace.
     """
+    split_prov = trace.getParameter('signal_split')
+    if isinstance(split_prov, list):
+        split_prov = split_prov[0]
+    split_time = split_prov['split_time']
+    noise = trace.copy().trim(endtime=split_time)
+    noise_mean = np.mean(noise.data)
+    trace.data = trace.data - noise_mean
     return trace
 
 

--- a/gmprocess/waveform_processing/sanity_checks.py
+++ b/gmprocess/waveform_processing/sanity_checks.py
@@ -8,7 +8,7 @@ This module is for waveform procesisng simple sanity checks.
 import numpy as np
 
 
-def check_tail(st, duration, max_vel_ratio=0.1, max_dis_ratio=0.1):
+def check_tail(st, duration, max_vel_ratio=0.1, max_dis_ratio=0.5):
     """Check for abnormally arge values in the tail of the stream.
 
     This QA check looks for the presence of abnomally large values in the tail
@@ -59,6 +59,7 @@ def check_tail(st, duration, max_vel_ratio=0.1, max_dis_ratio=0.1):
         tr.trim(starttime=new_start_time)
 
     for i in range(len(st)):
+        tr = st[i]
         abs_max_vel = np.max(np.abs(vel[i].data))
         abs_max_vel_trim = np.max(np.abs(vel_trim[i].data))
         abs_max_dis = np.max(np.abs(dis[i].data))

--- a/gmprocess/waveform_processing/sanity_checks.py
+++ b/gmprocess/waveform_processing/sanity_checks.py
@@ -70,5 +70,10 @@ def check_tail(st, duration, max_vel_ratio=0.1, max_dis_ratio=0.5):
             tr.fail('Velocity ratio is greater than %s' % max_vel_ratio)
         if dis_ratio > max_dis_ratio:
             tr.fail('Displacement ratio is greater than %s' % max_dis_ratio)
-
+        tail_conf = {
+            'max_vel_ratio': max_vel_ratio,
+            'max_dis_ratio': max_dis_ratio,
+            'start_time': new_start_time
+        }
+        tr.setParameter('tail_conf', tail_conf)
     return st

--- a/gmprocess/waveform_processing/sanity_checks.py
+++ b/gmprocess/waveform_processing/sanity_checks.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+This module is for waveform procesisng simple sanity checks.
+"""
+
+import numpy as np
+
+
+def check_tail(st, duration, max_vel_ratio=0.1, max_dis_ratio=0.1):
+    """Check for abnormally arge values in the tail of the stream.
+
+    This QA check looks for the presence of abnomally large values in the tail
+    velocity and displacement traces. This can occur due to baseline shifts or
+    long period noise that has not been properly filtered out that manifest
+    as long-period drifts in the velocity and/or displacement traces.
+
+    Note that an additional problem that this check should eliminate is records
+    in which the time window has not captured the full duration of shaking.
+
+    Args:
+        st (StationStream):
+            StationStream object.
+        duration (float):
+            Duration of tail.
+        max_vel_ratio (float):
+            Trace is labeled as failed if the max absolute velocity in the tail
+            is greater than max_vel_ratio times the max absolute velocity of
+            the whole trace.
+        max_dis_ratio (float):
+            Trace is labeled as failed if the max absolute displacement in the
+            tail is greater than max_disp_ratio times the max absolute
+            displacement of the whole trace.
+
+    Returns:
+
+    """
+    if not st.passed:
+        return st
+
+    start_time = st[0].stats.starttime
+    end_time = st[0].stats.endtime
+    new_start_time = end_time - duration
+    if new_start_time < start_time:
+        for tr in st:
+            tr.fail('Cannot apply tail check because tail duration exceeds'
+                    'record duration.')
+        return st
+
+    vel = st.copy().integrate()
+    dis = vel.copy().integrate()
+    vel_trim = vel.copy()
+    dis_trim = dis.copy()
+
+    for tr in vel_trim:
+        tr.trim(starttime=new_start_time)
+    for tr in dis_trim:
+        tr.trim(starttime=new_start_time)
+
+    for i in range(len(st)):
+        abs_max_vel = np.max(np.abs(vel[i].data))
+        abs_max_vel_trim = np.max(np.abs(vel_trim[i].data))
+        abs_max_dis = np.max(np.abs(dis[i].data))
+        abs_max_dis_trim = np.max(np.abs(dis_trim[i].data))
+        vel_ratio = abs_max_vel_trim / abs_max_vel
+        dis_ratio = abs_max_dis_trim / abs_max_dis
+        if vel_ratio > max_vel_ratio:
+            tr.fail('Velocity ratio is greater than %s' % max_vel_ratio)
+        if dis_ratio > max_dis_ratio:
+            tr.fail('Displacement ratio is greater than %s' % max_dis_ratio)
+
+    return st

--- a/gmprocess/waveform_processing/windows.py
+++ b/gmprocess/waveform_processing/windows.py
@@ -267,7 +267,7 @@ def signal_end(st, event_time, event_lon, event_lat, event_mag,
         rctx.mag = event_mag
         rctx.rake = -90.0
         dur_imt = imt.from_string('RSD595')
-        stddev_types = [const.StdDev.INTRA_EVENT]
+        stddev_types = [const.StdDev.TOTAL]
 
     for tr in st:
         if not tr.hasParameter('signal_split'):
@@ -342,25 +342,35 @@ def trim_multiple_events(st, origin, catalog, travel_time_df, pga_factor,
        selected in step #3.
 
     Args:
-        st (StationStream): Stream of data.
-        origin (ScalarEvent): ScalarEvent object associated with the StationStream.
-        catalog (list): List of ScalarEvent objects.
-        travel_time_df (DataFrame): A pandas DataFrame that contains the travel time information
-            (obtained from gmprocess.waveform_processing.phase.create_travel_time_dataframe).
+        st (StationStream):
+            Stream of data.
+        origin (ScalarEvent):
+            ScalarEvent object associated with the StationStream.
+        catalog (list):
+            List of ScalarEvent objects.
+        travel_time_df (DataFrame):
+            A pandas DataFrame that contains the travel time information
+            (obtained from
+             gmprocess.waveform_processing.phase.create_travel_time_dataframe).
             The columns in the DataFrame are the station ids and the indices
             are the earthquake ids.
-        pga_factor (float): A decimal factor used to determine whether the predicted PGA
+        pga_factor (float):
+            A decimal factor used to determine whether the predicted PGA
             from an event arrival is significant enough that it should be
             considered for removal.
-        pct_window_reject (float): A decimal from 0.0 to 1.0 used to determine if an arrival should
+        pct_window_reject (float):
+           A decimal from 0.0 to 1.0 used to determine if an arrival should
             be trimmed from the record, or if the entire record should be
             rejected. If the arrival falls within the first
             pct_window_reject * 100% of the signal window, then the entire
             record will be rejected. Otherwise, the record will be trimmed
             appropriately.
-        gmpe (str): Short name of the GMPE to use. Must be defined in the modules file.
-        site_parameters (dict): Dictionary of site parameters to input to the GMPE.
-        rupture_parameters: Dictionary of rupture parameters to input to the GMPE.
+        gmpe (str):
+            Short name of the GMPE to use. Must be defined in the modules file.
+        site_parameters (dict):
+            Dictionary of site parameters to input to the GMPE.
+        rupture_parameters:
+            Dictionary of rupture parameters to input to the GMPE.
 
     Returns:
         StationStream: Processed stream.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning

--- a/tests/gmprocess/io/asdf/asdf_layout_test.py
+++ b/tests/gmprocess/io/asdf/asdf_layout_test.py
@@ -80,9 +80,7 @@ def test_layout():
     with open(layout_abspath, "r", encoding='utf-8') as fin:
         lines = fin.readlines()
         for line in lines:
-            itype, item = line.split()
-            assert item in h5
-            assert isinstance(h5[item], LAYOUT_TYPES[itype])
+            assert line.strip() in h5
     h5.close()
     return
 

--- a/tests/gmprocess/io/obspy/obspy_test.py
+++ b/tests/gmprocess/io/obspy/obspy_test.py
@@ -136,7 +136,7 @@ def test_weird_sensitivity():
     sc = StreamCollection(streams)
     psc = process_streams(sc, origin)
     channel = psc[0].select(component='E')[0]
-    assert_almost_equal(channel.data.max(), 62900.195313894299)
+    assert_almost_equal(channel.data.max(), 62900.197618074293)
 
 
 def test():

--- a/tests/gmprocess/waveform_processing/processing_test.py
+++ b/tests/gmprocess/waveform_processing/processing_test.py
@@ -55,7 +55,7 @@ def test_process_streams():
 
     np.testing.assert_allclose(
         trace_maxes,
-        np.array([157.81975508, 240.33718094, 263.67804256]),
+        np.array([157.812449, 240.379521, 263.601519]),
         rtol=1e-5
     )
 

--- a/tests/gmprocess/waveform_processing/windows_test.py
+++ b/tests/gmprocess/waveform_processing/windows_test.py
@@ -161,7 +161,7 @@ def test_trim_multiple_events():
                              {'vs30': 760}, {'rake': 0})
 
     num_failures = sum([1 if not st.passed else 0 for st in sc])
-    assert num_failures == 1
+    assert num_failures == 2
 
     failure = sc.select(station='WRV2')[0][0].getParameter('failure')
     assert failure['module'] == 'trim_multiple_events'
@@ -172,7 +172,7 @@ def test_trim_multiple_events():
     for tr in sc.select(station='JRC2')[0]:
         np.testing.assert_almost_equal(
             tr.stats.endtime,
-            UTCDateTime('2019-07-06T03:20:38.7983Z'))
+            UTCDateTime('2019-07-06T03:20:56.368300Z'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- add sanity checks on tail for velocity and displacement
- added displacement plot to report
- added sanity check thresholds to plot
- fix bug in epsilon for signal window duration

The thresholds here are pretty weak and it may seem like stronger criteria is warranted. But the issue is that records from CESMD are often not long enough for velocity and displacement to have quieted down enough for a stricter threshold. Longer duration records would help. Future refinements are probably warranted, e.g., could use the mean value of the tail rather than the max. 

Note: I had to change some of the unit test results due to the bug fix on the window duration. 

Closes #714.