### PR TITLE
Do not create list of all streams prior to loops

### DIFF
--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -452,14 +452,14 @@ class StreamWorkspace(object):
         streams = []
 
         if stations is None:
-            stations = self.getStations(eventid)
+            stations = self.getStations()
         if labels is None:
             labels = self.getLabels()
 
         for waveform in self.dataset.ifilter(
-            self.dataset.q.station == stations,
-            self.dataset.q.tag == ['%s_%s' % (eventid, label)
-                                   for label in labels]):
+                self.dataset.q.station == stations,
+                self.dataset.q.tag == ['%s_%s' % (eventid, label)
+                                       for label in labels]):
             tags = waveform.get_waveform_tags()
             for tag in tags:
                 tstream = waveform[tag]
@@ -548,7 +548,7 @@ class StreamWorkspace(object):
             streams, handle_duplicates=False, config=config)
         return streams
 
-    def getStations(self, eventid=None):
+    def getStations(self):
         """Get list of station codes within the file.
 
         Args:
@@ -1234,7 +1234,7 @@ class StreamWorkspace(object):
 
         """
         if stations is None:
-            stations = self.getStations(eventid)
+            stations = self.getStations()
         if labels is None:
             labels = self.getLabels()
         cols = ['Record', 'Processing Step',

--- a/gmprocess/subcommands/base.py
+++ b/gmprocess/subcommands/base.py
@@ -173,3 +173,32 @@ class SubcommandModule(ABC):
                 self.gmrecords.args.label = tmplab
         elif self.gmrecords.args.label is None:
             self.gmrecords.args.label = labels[0]
+
+    @staticmethod
+    def _waveform_to_stations(waveform):
+        stations = []
+        for stream_name, _ in waveform.get_waveform_attributes().items():
+            parts = stream_name.split('.')
+            station = parts[1]
+            if station in stations:
+                continue
+            stations.append(station)
+        return stations
+
+    def _waveform_to_stream(self, waveform, eventid):
+        stations = self._waveform_to_stations(waveform)
+        sc = self.workspace.getStreams(
+            eventid,
+            stations=stations,
+            labels=[self.gmrecords.args.label],
+            config=self.gmrecords.conf
+        )
+        if len(sc) == 1:
+            stream = sc[0]
+        elif len(sc) == 0:
+            logging.info('Empty StreamCollection for: %s' % waveform)
+        else:
+            logging.info('Multiple streams in StreamCollection for %s, '
+                         'continuing with the first one.' % waveform)
+            stream = sc[0]
+        return stream

--- a/gmprocess/subcommands/compute_waveform_metrics.py
+++ b/gmprocess/subcommands/compute_waveform_metrics.py
@@ -75,14 +75,12 @@ class ComputeWaveformMetricsModule(SubcommandModule):
             return event.id
 
         self.workspace = StreamWorkspace.open(workname)
-        self._get_pstreams()
+        ds = self.workspace.dataset
+        self._get_labels()
 
-        if not (hasattr(self, 'pstreams') and len(self.pstreams) > 0):
-            logging.info('No streams found. Nothing to do. Goodbye.')
-            self.workspace.close()
-            return event.id
+        for waveform in ds.waveforms:
+            stream = self._waveform_to_stream(waveform, event.id)
 
-        for stream in self.pstreams:
             if stream.passed:
                 logging.info(
                     'Calculating waveform metrics for %s...'

--- a/tests/gmprocess/io/asdf/stream_workspace_test.py
+++ b/tests/gmprocess/io/asdf/stream_workspace_test.py
@@ -17,7 +17,7 @@ from gmprocess.core.streamcollection import StreamCollection
 from gmprocess.io.fetch_utils import get_rupture_file, update_config
 
 from h5py.h5py_warnings import H5pyDeprecationWarning
-from ruamel.yaml.error import YAMLError 
+from ruamel.yaml.error import YAMLError
 
 import numpy as np
 import pandas as pd
@@ -123,7 +123,7 @@ def _test_workspace():
             stations = workspace.getStations()
             assert sorted(stations) == ['HSES', 'THZ', 'WTMC']
 
-            stations = workspace.getStations(eventid=eventid)
+            stations = workspace.getStations()
             assert sorted(stations) == ['HSES', 'THZ', 'WTMC']
 
             # test retrieving event that doesn't exist
@@ -194,7 +194,7 @@ def _test_workspace():
             workspace = StreamWorkspace.open(tfile)
             workspace.addStreams(event, raw_streams, label='foo')
 
-            stations = workspace.getStations(eventid)
+            stations = workspace.getStations()
 
             eventids = workspace.getEventIds()
             assert eventids == ['us1000778i', 'nz2018p115908']


### PR DESCRIPTION
As a first step towards #710, `adjust compute_station_metrics`, `compute_waveform_metrics`, and `process_waveforms` subcommands to not pre-load all the streams for a given event. Instead, these now load one stream at a time within the loop. This should help with future optimization efforts, and maybe even will be somewhat more efficient from not having to load so much into memory all at once. 