### PR TITLE
Fixed eventtime extracted from event.json

### DIFF
--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -264,7 +264,7 @@ class StreamWorkspace(object):
 
     def addConfig(self):
         """Add config to an ASDF file.
-        
+
         """
         config = get_config()
         config_bytes = json.dumps(config).encode('utf-8')

--- a/gmprocess/io/fetch_utils.py
+++ b/gmprocess/io/fetch_utils.py
@@ -383,11 +383,10 @@ def read_event_json_files(eventfiles):
             event = json.load(f)
 
             try:
-                origintime = datetime.fromtimestamp(
-                    event["properties"]["time"] / 1000.0)
                 evdict = {
                     "id": event["id"],
-                    "time": origintime.strftime("%Y-%m-%dT%H:%M:%S.%f"),
+                    "time": event['properties']['products']['dyfi'][0]
+                    ['properties']['eventtime'],
                     "lat": event["geometry"]["coordinates"][1],
                     "lon": event["geometry"]["coordinates"][0],
                     "depth": event["geometry"]["coordinates"][2],

--- a/gmprocess/io/obspy/fdsn_fetcher.py
+++ b/gmprocess/io/obspy/fdsn_fetcher.py
@@ -265,7 +265,7 @@ class FDSNFetcher(DataFetcher):
                         client = Client(
                             provider_str,
                             user=fdsn_config[provider_str]['user'],
-                            password=fdsn_config[provider_str]['password']) 
+                            password=fdsn_config[provider_str]['password'])
                 else:
                     if logging.getLevelName(root.level) == 'DEBUG':
                         client = Client(provider_str, debug=True)


### PR DESCRIPTION
The previous method was resulting in a local time instead of UTC from the event.json. This commit extracts the event time in UTC format directly from the event.json.

autopep8 was also used on the commited files.