### PR TITLE
Exclude networks giving spurious results

### DIFF
--- a/gmprocess/data/config_production.yml
+++ b/gmprocess/data/config_production.yml
@@ -59,6 +59,10 @@ fetchers:
         # SY is a network for synthetic data
         exclude_networks :
             - SY
+            - ZY
+            - YH
+            - YG
+            - AM
 
         # uncomment this section to add stations that should be avoided
         # exclude_stations:


### PR DESCRIPTION
Short term measure to avoid problematic networks reported in #780. 