### PR TITLE
Fix mis-aligned columns in metric tables

### DIFF
--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -498,12 +498,12 @@ class StreamWorkspace(object):
 
         net_codes = [st.split('.')[0] for st in stations]
         sta_codes = [st.split('.')[1] for st in stations]
+        tag = ['%s_%s' % (eventid, label) for label in labels]
 
         for waveform in self.dataset.ifilter(
                 self.dataset.q.network == net_codes,
                 self.dataset.q.station == sta_codes,
-                self.dataset.q.tag == [
-                    '%s_%s' % (eventid, label) for label in labels]):
+                self.dataset.q.tag == tag):
             tags = waveform.get_waveform_tags()
             for tag in tags:
                 tstream = waveform[tag]
@@ -672,7 +672,7 @@ class StreamWorkspace(object):
 
         # Load the rupture file
         origin = Origin({
-            'id': event.id,
+            'id': event.resource_id.id.replace('smi:local/', ''),
             'netid': '',
             'network': '',
             'lat': event.latitude,
@@ -728,18 +728,15 @@ class StreamWorkspace(object):
                 ])
                 self.insert_aux(xmlstr, 'StationMetrics', metricpath)
 
-    def getTables(self, label, streams=None, stream_label=None):
+    def getTables(self, label, config):
         '''Retrieve dataframes containing event information and IMC/IMT
         metrics.
 
         Args:
             label (str):
                 Calculate metrics only for the given label.
-            streams (StreamCollection):
-                Optional StreamCollection object to get tables for.
-            stream_label (str):
-                Label to be used in the metrics path when providing a
-                StreamCollection.
+            config (dict):
+                Config options.
 
         Returns:
             tuple: Elements are:
@@ -786,7 +783,7 @@ class StreamWorkspace(object):
         for eventid in self.getEventIds():
             event = self.getEvent(eventid)
             event_info.append({
-                'id': event.id.replace('smi:local/', ''),
+                'id': event.resource_id.id.replace('smi:local/', ''),
                 'time': event.time,
                 'latitude': event.latitude,
                 'longitude': event.longitude,
@@ -795,55 +792,69 @@ class StreamWorkspace(object):
                 'magnitude_type': event.magnitude_type
             })
 
-            if streams is None:
-                streams = self.getStreams(eventid, labels=[label])
+            station_list = self.dataset.waveforms.list()
 
-            for stream in streams:
-                if not stream.passed:
-                    continue
+            for station_id in station_list:
+                streams = self.getStreams(
+                    event.resource_id.id.replace('smi:local/', ''),
+                    stations=[station_id],
+                    labels=[label],
+                    config=config
+                )
+                if not len(streams):
+                    raise ValueError('No matching streams found.')
 
-                station = stream[0].stats.station
-                network = stream[0].stats.network
-                summary = self.getStreamMetrics(
-                    eventid, network, station, label, streams=[stream],
-                    stream_label=stream_label)
+                for stream in streams:
+                    if not stream.passed:
+                        continue
 
-                if summary is None:
-                    continue
+                    station = stream[0].stats.station
+                    network = stream[0].stats.network
+                    summary = self.getStreamMetrics(
+                        eventid, network, station, label, streams=[stream],
+                        stream_label=label)
 
-                pgms = summary.pgms
-                imclist = pgms.index.get_level_values('IMC').unique().tolist()
-                imtlist = pgms.index.get_level_values('IMT').unique().tolist()
-                imtlist.sort(key=_natural_keys)
+                    if summary is None:
+                        continue
 
-                # Add any Vs30 columns to the list of FLATFILE_COLUMNS
-                for vs30_dict in summary._vs30.values():
-                    FLATFILE_COLUMNS[vs30_dict['column_header']] = \
-                        vs30_dict['readme_entry']
+                    pgms = summary.pgms
+                    imclist = pgms.index.get_level_values(
+                        'IMC').unique().tolist()
+                    imtlist = pgms.index.get_level_values(
+                        'IMT').unique().tolist()
+                    imtlist.sort(key=_natural_keys)
 
-                for imc in imclist:
-                    if imc not in imc_tables:
-                        row = _get_table_row(stream, summary, event, imc)
-                        if not len(row):
-                            continue
-                        imc_tables[imc] = [row]
-                    else:
-                        row = _get_table_row(stream, summary, event, imc)
-                        if not len(row):
-                            continue
-                        imc_tables[imc].append(row)
+                    # Add any Vs30 columns to the list of FLATFILE_COLUMNS
+                    for vs30_dict in summary._vs30.values():
+                        FLATFILE_COLUMNS[vs30_dict['column_header']] = \
+                            vs30_dict['readme_entry']
+
+                    for imc in imclist:
+                        if imc not in imc_tables:
+                            row = _get_table_row(stream, summary, event, imc)
+                            if not len(row):
+                                continue
+                            imc_tables[imc] = [row]
+                        else:
+                            row = _get_table_row(stream, summary, event, imc)
+                            if not len(row):
+                                continue
+                            imc_tables[imc].append(row)
 
         # Remove any empty IMT columns from the IMC tables
         for key, table in imc_tables.items():
             table = pd.DataFrame.from_dict(table)
-            have_imts = []
-            for imt in list(set(table.columns) & set(imtlist)):
-                if not pd.isna(table[imt]).all():
-                    have_imts.append(imt)
-            have_imts.sort(key=_natural_keys)
-            non_imt_cols = [
-                col for col in table.columns if col not in imtlist]
-            table = table[non_imt_cols + have_imts]
+            imt_cols = list(set(table.columns) & set(imtlist))
+
+            # Remove FAS?
+            fas_cols = [c for c in imt_cols if c.startswith('FAS(')]
+            fas_df = table[fas_cols]
+            if pd.isna(fas_df).all(axis=None):
+                imt_cols = [x for x in imt_cols if x not in fas_cols]
+            imt_cols.sort(key=_natural_keys)
+
+            non_imt_cols = [col for col in table.columns if col not in imtlist]
+            table = table[non_imt_cols + imt_cols]
             imc_tables[key] = table
             readme_dict = {}
             for col in table.columns:
@@ -954,7 +965,7 @@ class StreamWorkspace(object):
         # Get list of periods in SA to interpolate SNR to.
         if 'WaveFormMetrics' not in self.dataset.auxiliary_data:
             logging.error('No WaveFormMetrics found. Please run '
-                          '\'compute_waverom_metrics\' subcommand.')
+                          '\'compute_waveform_metrics\' subcommand.')
         wm = self.dataset.auxiliary_data.WaveFormMetrics
         wm_tmp = wm[wm.list()[0]]
         bytelist = wm_tmp[wm_tmp.list()[0]].data[:].tolist()

--- a/gmprocess/subcommands/export_metric_tables.py
+++ b/gmprocess/subcommands/export_metric_tables.py
@@ -56,25 +56,19 @@ class ExportMetricTablesModule(SubcommandModule):
                 continue
 
             self.workspace = StreamWorkspace.open(workname)
-            self._get_pstreams()
-
-            if not (hasattr(self, 'pstreams') and len(self.pstreams) > 0):
-                logging.info('No processed waveforms available. No metric '
-                             'tables created.')
-                self.workspace.close()
-                continue
+            self._get_labels()
 
             event_table, imc_tables, readmes = self.workspace.getTables(
                 self.gmrecords.args.label, self.gmrecords.conf)
             ev_fit_spec, fit_readme = self.workspace.getFitSpectraTable(
-                self.eventid, self.gmrecords.args.label, self.pstreams)
+                self.eventid, self.gmrecords.args.label, self.gmrecords.conf)
 
             # We need to have a consistent set of frequencies for reporting the
             # SNR. For now, I'm going to take it from the SA period list, but
             # this could be changed to something else, or even be set via the
             # config file.
             snr_table, snr_readme = self.workspace.getSNRTable(
-                self.eventid, self.gmrecords.args.label, self.pstreams)
+                self.eventid, self.gmrecords.args.label, self.gmrecords.conf)
             self.workspace.close()
 
             outdir = gmrecords.data_path

--- a/gmprocess/subcommands/export_metric_tables.py
+++ b/gmprocess/subcommands/export_metric_tables.py
@@ -65,7 +65,7 @@ class ExportMetricTablesModule(SubcommandModule):
                 continue
 
             event_table, imc_tables, readmes = self.workspace.getTables(
-                self.gmrecords.args.label, streams=self.pstreams)
+                self.gmrecords.args.label, self.gmrecords.conf)
             ev_fit_spec, fit_readme = self.workspace.getFitSpectraTable(
                 self.eventid, self.gmrecords.args.label, self.pstreams)
 

--- a/gmprocess/subcommands/generate_report.py
+++ b/gmprocess/subcommands/generate_report.py
@@ -105,18 +105,23 @@ class GenerateReportModule(SubcommandModule):
         results = []
         pstreams = []
         for station_id in station_list:
-            stream = self.workspace.getStreams(
+            streams = self.workspace.getStreams(
                 event.id,
                 stations=[station_id],
                 labels=[self.gmrecords.args.label],
                 config=self.gmrecords.conf
-            )[0]
-            pstreams.append(stream)
-            if self.gmrecords.args.num_processes > 0:
-                future = client.submit(summary_plots, stream, plot_dir, event)
-                futures.append(future)
-            else:
-                results.append(summary_plots(stream, plot_dir, event))
+            )
+            if not len(streams):
+                raise ValueError('No matching streams found.')
+
+            for stream in streams:
+                pstreams.append(stream)
+                if self.gmrecords.args.num_processes > 0:
+                    future = client.submit(
+                        summary_plots, stream, plot_dir, event)
+                    futures.append(future)
+                else:
+                    results.append(summary_plots(stream, plot_dir, event))
 
         if self.gmrecords.args.num_processes > 0:
             # Collect the results??

--- a/gmprocess/subcommands/generate_station_maps.py
+++ b/gmprocess/subcommands/generate_station_maps.py
@@ -64,13 +64,17 @@ class GenerateHTMLMapModule(SubcommandModule):
 
             pstreams = []
             for station_id in station_list:
-                stream = self.workspace.getStreams(
+                streams = self.workspace.getStreams(
                     event.id,
                     stations=[station_id],
                     labels=[self.gmrecords.args.label],
                     config=self.gmrecords.conf
-                )[0]
-                pstreams.append(stream)
+                )
+                if not len(streams):
+                    raise ValueError('No matching streams found.')
+
+                for stream in streams:
+                    pstreams.append(stream)
 
             mapfiles = draw_stations_map(pstreams, event, event_dir)
             for file in mapfiles:

--- a/gmprocess/subcommands/process_waveforms.py
+++ b/gmprocess/subcommands/process_waveforms.py
@@ -80,24 +80,25 @@ class ProcessWaveformsModule(SubcommandModule):
 
         for station_id in station_list:
             # Cannot parallelize IO to ASDF file
-            raw_stream = workspace.getStreams(
+            raw_streams = workspace.getStreams(
                 event.id,
                 stations=[station_id],
                 labels=['unprocessed'],
                 config=self.gmrecords.conf
             )
 
-            if len(raw_stream):
+            if len(raw_streams):
                 logging.info('Processing \'%s\' streams for event %s...'
                              % ('unprocessed', event.id))
                 if self.gmrecords.args.num_processes > 0:
                     future = client.submit(
-                        process_streams, raw_stream, event,
+                        process_streams, raw_streams, event,
                         self.gmrecords.conf)
                     futures.append(future)
                 else:
                     processed_streams.append(
-                        process_streams(raw_stream, event, self.gmrecords.conf)
+                        process_streams(
+                            raw_streams, event, self.gmrecords.conf)
                     )
 
         if self.gmrecords.args.num_processes > 0:


### PR DESCRIPTION
Closes #779. The source of the problem is that we have some IMT-IMC combos that don't make sense (e.g., ROTD50 and FAS). These give all nans in the columns for FAS in the ROTD50 table, which is inconvenient and looks bad. So we tried removed any columns in which all rows were nans. But this creates a mismatch from event-to-event if there are sometimes columns that are all nans for other reasons, and we didn't anticipate this. The updated code now removes all the FAS columns if the contents are all nans. This resolves the problem in the data provided by @arkottke and I believe that it solves the problem more generally. 
