### PR TITLE
Adjust response removal for ?H? instruments

### DIFF
--- a/gmprocess/data/config_production.yml
+++ b/gmprocess/data/config_production.yml
@@ -215,9 +215,6 @@ processing:
     #     threshold: 3.0
 
     - remove_response:
-        # Outuput units. Must be 'ACC', 'VEL', or 'DISP'.
-        output: 'ACC'
-
         # Pre-filtering frequencies. See obspy.core.trace.Trace.remove_response
         # for details. Note: if f3 is Null it will be set to 0.9*fn, if f4 is
         # Null it will be set to fn.

--- a/gmprocess/data/config_test.yml
+++ b/gmprocess/data/config_test.yml
@@ -201,9 +201,6 @@ processing:
     #     threshold: 3.0
 
     - remove_response:
-        # Outuput units. Must be 'ACC', 'VEL', or 'DISP'.
-        output: 'ACC'
-
         # Pre-filtering frequencies. See obspy.core.trace.Trace.remove_response
         # for details. Note: if f3 is Null it will be set to 0.9*fn, if f4 is
         # Null it will be set to fn.

--- a/gmprocess/data/testdata/conf_small.yml
+++ b/gmprocess/data/testdata/conf_small.yml
@@ -173,9 +173,6 @@ processing:
         threshold: 3.0
 
     - remove_response:
-        # Outuput units. Must be 'ACC', 'VEL', or 'DISP'.
-        output: 'ACC'
-
         # Pre-filtering frequencies. See obspy.core.trace.Trace.remove_response
         # for details. Note: if f3 is Null it will be set to 0.9*fn, if f4 is
         # Null it will be set to fn.

--- a/gmprocess/data/testdata/config_min_freq_0p2.yml
+++ b/gmprocess/data/testdata/config_min_freq_0p2.yml
@@ -177,9 +177,6 @@ processing:
     #     threshold: 3.0
 
     - remove_response:
-        # Outuput units. Must be 'ACC', 'VEL', or 'DISP'.
-        output: 'ACC'
-
         # Pre-filtering frequencies. See obspy.core.trace.Trace.remove_response
         # for details. Note: if f3 is Null it will be set to 0.9*fn, if f4 is
         # Null it will be set to fn.

--- a/tests/gmprocess/waveform_processing/lowpass_max_test.py
+++ b/tests/gmprocess/waveform_processing/lowpass_max_test.py
@@ -25,7 +25,7 @@ def test_lowpass_max():
             {'detrend': {'detrending_method': 'demean'}},
             {'remove_response': {
                 'f1': 0.001, 'f2': 0.005, 'f3': None, 'f4': None,
-                'output': 'ACC', 'water_level': 60}
+                'water_level': 60}
              },
             #            {'detrend': {'detrending_method': 'linear'}},
             #            {'detrend': {'detrending_method': 'demean'}},


### PR DESCRIPTION
This changes the output on the `remove_response` function from acceleration to velocity, and then differentiates the result, as suggested [here](https://github.com/usgs/groundmotion-processing/issues/772#issuecomment-967207056). Also, I removed `output` as an option from the config, and this will break for anyone who is using an older config with the updated code. 