### PR TITLE
Fail gracefully (avoid raising exceptions) in subcommands when there is no waveform data

### DIFF
--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -899,6 +899,8 @@ class StreamWorkspace(object):
         """
         fit_table = []
         event = self.getEvent(eventid)
+        if not event:
+            return (None, None)
 
         station_list = self.dataset.waveforms.list()
         for station_id in station_list:
@@ -1269,10 +1271,7 @@ class StreamWorkspace(object):
             if event.resource_id.id.find(eventid) > -1:
                 eventobj = event
                 break
-        if eventobj is None:
-            fmt = "Event with a resource id containing %s could not be found."
-            raise KeyError(fmt % eventid)
-        eventobj2 = ScalarEvent.fromEvent(eventobj)
+        eventobj2 = ScalarEvent.fromEvent(eventobj) if eventobj else None
         return eventobj2
 
     def getProvenance(self, eventid, stations=None, labels=None):

--- a/gmprocess/subcommands/compute_station_metrics.py
+++ b/gmprocess/subcommands/compute_station_metrics.py
@@ -86,6 +86,11 @@ class ComputeStationMetricsModule(base.SubcommandModule):
         ds = self.workspace.dataset
         self._get_labels()
 
+        station_list = ds.waveforms.list()
+        if not len(station_list):
+            self.workspace.close()
+            return event.id
+
         rupture_file = rupt_utils.get_rupture_file(event_dir)
         origin = rupt.origin.Origin(
             {
@@ -110,7 +115,6 @@ class ComputeStationMetricsModule(base.SubcommandModule):
         self.sta_rhyp = []
         self.sta_baz = []
 
-        station_list = ds.waveforms.list()
         self._get_labels()
 
         for station_id in station_list:

--- a/gmprocess/subcommands/export_metric_tables.py
+++ b/gmprocess/subcommands/export_metric_tables.py
@@ -120,7 +120,7 @@ class ExportMetricTablesModule(base.SubcommandModule):
                 output_format = "xlsx"
 
             for filename, df in dict(zip(filenames, files)).items():
-                if df is None:
+                if df is None or df.size == 0:
                     continue
                 filepath = os.path.normpath(
                     os.path.join(outdir, filename + f".{output_format}")

--- a/gmprocess/subcommands/generate_report.py
+++ b/gmprocess/subcommands/generate_report.py
@@ -86,12 +86,11 @@ class GenerateReportModule(base.SubcommandModule):
         self.workspace = ws.StreamWorkspace.open(workname)
         ds = self.workspace.dataset
         station_list = ds.waveforms.list()
-        self._get_labels()
-
         if len(station_list) == 0:
             logging.info("No processed waveforms available. No report generated.")
-            return False
+            return []
 
+        self._get_labels()
         if self.gmrecords.args.num_processes > 0:
             futures = []
             client = distributed.Client(

--- a/gmprocess/subcommands/generate_station_maps.py
+++ b/gmprocess/subcommands/generate_station_maps.py
@@ -54,12 +54,11 @@ class GenerateHTMLMapModule(base.SubcommandModule):
             self.workspace = ws.StreamWorkspace.open(workname)
             ds = self.workspace.dataset
             station_list = ds.waveforms.list()
-            self._get_labels()
-
             if len(station_list) == 0:
                 logging.info("No processed waveforms available. No report generated.")
                 return False
 
+            self._get_labels()
             logging.info(f"Generating station maps for event {event.id}...")
 
             pstreams = []


### PR DESCRIPTION
Avoid exceptions when running subcommands with no waveform data.

Allows the following subcommands to fail gracefully (print warning without throwing exception):
* compute_station_metrics
* export_metric_tables
* generate_report
* generate_station_maps