### PR TITLE
Projects

### DIFF
--- a/gmprocess/apps/gmrecords.py
+++ b/gmprocess/apps/gmrecords.py
@@ -144,7 +144,7 @@ class GMrecordsApp(object):
             sys.exit(1)
 
         # Only run get_config for assemble and projects
-        subcommands_need_conf = ["assemble"]
+        subcommands_need_conf = ["assemble", "auto_shakemap"]
         if self.args.func.command_name in subcommands_need_conf:
             self.conf = config.get_config(self.conf_file)
 

--- a/gmprocess/apps/gmrecords.py
+++ b/gmprocess/apps/gmrecords.py
@@ -142,7 +142,8 @@ class GMrecordsApp(object):
             print(f"Config file does not exist: {self.conf_file}")
             print("Exiting.")
             sys.exit(1)
-        self.conf = config.get_config(self.conf_file)
+        if "projects" not in self.args.func.command_name:
+            self.conf = config.get_config(self.conf_file)
 
     def _initial_setup(self):
         """

--- a/gmprocess/apps/gmrecords.py
+++ b/gmprocess/apps/gmrecords.py
@@ -142,7 +142,10 @@ class GMrecordsApp(object):
             print(f"Config file does not exist: {self.conf_file}")
             print("Exiting.")
             sys.exit(1)
-        if "projects" not in self.args.func.command_name:
+
+        # Only run get_config for assemble and projects
+        subcommands_need_conf = ["assemble"]
+        if self.args.func.command_name in subcommands_need_conf:
             self.conf = config.get_config(self.conf_file)
 
     def _initial_setup(self):

--- a/gmprocess/io/asdf/stream_workspace.py
+++ b/gmprocess/io/asdf/stream_workspace.py
@@ -331,7 +331,11 @@ class StreamWorkspace(object):
         # base provenance document that will be copied and used as a template
         base_prov = prov.model.ProvDocument()
         base_prov.add_namespace(*NS_SEIS)
-        base_prov = _get_person_agent(base_prov, self.config)
+        if hasattr(self, "config"):
+            config = self.config
+        else:
+            config = get_config()
+        base_prov = _get_person_agent(base_prov, config)
         base_prov = _get_software_agent(base_prov, gmprocess_version)
 
         logging.debug(streams)

--- a/gmprocess/io/utils.py
+++ b/gmprocess/io/utils.py
@@ -10,7 +10,6 @@ import numpy as np
 # local imports
 from gmprocess.utils.config import get_config
 
-CONFIG = get_config()
 DUPLICATE_MARKER = "1"
 
 
@@ -52,7 +51,9 @@ def is_evenly_spaced(times, rtol=1e-6, atol=1e-8):
     return np.all(np.isclose(diff_times[0], diff_times, rtol=rtol, atol=atol))
 
 
-def resample_uneven_trace(trace, times, data, resample_rate=None, method="linear"):
+def resample_uneven_trace(
+    trace, times, data, resample_rate=None, method="linear", config=None
+):
     """
     Resample unevenly spaced data.
 
@@ -67,6 +68,8 @@ def resample_uneven_trace(trace, times, data, resample_rate=None, method="linear
             Resampling rate in Hz.
         method (str):
             Method of resampling. Currently only supported is 'linear'.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         trace (gmprocess.core.stationtrace.StationTrace):
@@ -78,7 +81,9 @@ def resample_uneven_trace(trace, times, data, resample_rate=None, method="linear
 
     # Load the resampling rate from the config if not provided
     if resample_rate is None:
-        resample_rate = CONFIG["read"]["resample_rate"]
+        if config is None:
+            config = get_config()
+        resample_rate = config["read"]["resample_rate"]
 
     new_times = np.arange(times[0], times[-1], 1 / resample_rate)
 

--- a/gmprocess/subcommands/base.py
+++ b/gmprocess/subcommands/base.py
@@ -99,8 +99,9 @@ class SubcommandModule(ABC):
         if self.gmrecords.args.label is None:
             return
 
+        config = self.workspace.config
         self.pstreams = self.workspace.getStreams(
-            self.eventid, labels=[self.gmrecords.args.label], config=self.gmrecords.conf
+            self.eventid, labels=[self.gmrecords.args.label], config=config
         )
 
     def _get_events(self):

--- a/gmprocess/subcommands/base.py
+++ b/gmprocess/subcommands/base.py
@@ -9,6 +9,7 @@ import logging
 from gmprocess.subcommands.lazy_loader import LazyLoader
 
 base_utils = LazyLoader("base_utils", globals(), "gmprocess.utils.base_utils")
+confmod = LazyLoader("confmod", globals(), "gmprocess.utils.config")
 
 
 class SubcommandModule(ABC):
@@ -99,7 +100,11 @@ class SubcommandModule(ABC):
         if self.gmrecords.args.label is None:
             return
 
-        config = self.workspace.config
+        if hasattr(self.workspace, "config"):
+            config = self.workspace.config
+        else:
+            config = confmod.get_config()
+
         self.pstreams = self.workspace.getStreams(
             self.eventid, labels=[self.gmrecords.args.label], config=config
         )

--- a/gmprocess/subcommands/compute_station_metrics.py
+++ b/gmprocess/subcommands/compute_station_metrics.py
@@ -22,6 +22,7 @@ ws = LazyLoader("ws", globals(), "gmprocess.io.asdf.stream_workspace")
 station_summary = LazyLoader(
     "station_summary", globals(), "gmprocess.metrics.station_summary"
 )
+confmod = LazyLoader("confmod", globals(), "gmprocess.utils.config")
 
 M_PER_KM = 1000
 
@@ -76,7 +77,11 @@ class ComputeStationMetricsModule(base.SubcommandModule):
         ds = self.workspace.dataset
         self._get_labels()
 
-        config = self.workspace.config
+        if hasattr(self.workspace, "config"):
+            config = self.workspace.config
+        else:
+            config = confmod.get_config()
+
         if not hasattr(self, "vs30_grids"):
             vs30_grids = None
             if config is not None:

--- a/gmprocess/subcommands/compute_waveform_metrics.py
+++ b/gmprocess/subcommands/compute_waveform_metrics.py
@@ -65,6 +65,7 @@ class ComputeWaveformMetricsModule(base.SubcommandModule):
         ds = self.workspace.dataset
         station_list = ds.waveforms.list()
         self._get_labels()
+        config = self.workspace.config
 
         summaries = []
         metricpaths = []
@@ -78,7 +79,7 @@ class ComputeWaveformMetricsModule(base.SubcommandModule):
                 event.id,
                 stations=[station_id],
                 labels=[self.gmrecords.args.label],
-                config=self.gmrecords.conf,
+                config=config,
             )
             if not len(streams):
                 raise ValueError("No matching streams found.")
@@ -102,7 +103,7 @@ class ComputeWaveformMetricsModule(base.SubcommandModule):
                         future = client.submit(
                             station_summary.StationSummary.from_config,
                             stream=stream,
-                            config=self.gmrecords.conf,
+                            config=config,
                             event=event,
                             calc_waveform_metrics=True,
                             calc_station_metrics=False,
@@ -113,7 +114,7 @@ class ComputeWaveformMetricsModule(base.SubcommandModule):
                             station_summary.StationSummary.from_config(
                                 stream,
                                 event=event,
-                                config=self.gmrecords.conf,
+                                config=config,
                                 calc_waveform_metrics=True,
                                 calc_station_metrics=False,
                             )

--- a/gmprocess/subcommands/compute_waveform_metrics.py
+++ b/gmprocess/subcommands/compute_waveform_metrics.py
@@ -14,6 +14,7 @@ station_summary = LazyLoader(
     "station_summary", globals(), "gmprocess.metrics.station_summary"
 )
 const = LazyLoader("const", globals(), "gmprocess.utils.constants")
+confmod = LazyLoader("confmod", globals(), "gmprocess.utils.config")
 
 
 class ComputeWaveformMetricsModule(base.SubcommandModule):
@@ -65,7 +66,10 @@ class ComputeWaveformMetricsModule(base.SubcommandModule):
         ds = self.workspace.dataset
         station_list = ds.waveforms.list()
         self._get_labels()
-        config = self.workspace.config
+        if hasattr(self.workspace, "config"):
+            config = self.workspace.config
+        else:
+            config = confmod.get_config()
 
         summaries = []
         metricpaths = []

--- a/gmprocess/subcommands/export_metric_tables.py
+++ b/gmprocess/subcommands/export_metric_tables.py
@@ -11,6 +11,7 @@ base = LazyLoader("base", globals(), "gmprocess.subcommands.base")
 ws = LazyLoader("ws", globals(), "gmprocess.io.asdf.stream_workspace")
 const = LazyLoader("const", globals(), "gmprocess.utils.constants")
 tables = LazyLoader("tables", globals(), "gmprocess.utils.tables")
+confmod = LazyLoader("confmod", globals(), "gmprocess.utils.config")
 
 
 class ExportMetricTablesModule(base.SubcommandModule):
@@ -55,7 +56,10 @@ class ExportMetricTablesModule(base.SubcommandModule):
 
             self.workspace = ws.StreamWorkspace.open(workname)
             self._get_labels()
-            config = self.workspace.config
+            if hasattr(self.workspace, "config"):
+                config = self.workspace.config
+            else:
+                config = confmod.get_config()
 
             event_table, imc_tables, readmes = self.workspace.getTables(
                 self.gmrecords.args.label, config

--- a/gmprocess/subcommands/export_metric_tables.py
+++ b/gmprocess/subcommands/export_metric_tables.py
@@ -55,12 +55,13 @@ class ExportMetricTablesModule(base.SubcommandModule):
 
             self.workspace = ws.StreamWorkspace.open(workname)
             self._get_labels()
+            config = self.workspace.config
 
             event_table, imc_tables, readmes = self.workspace.getTables(
-                self.gmrecords.args.label, self.gmrecords.conf
+                self.gmrecords.args.label, config
             )
             ev_fit_spec, fit_readme = self.workspace.getFitSpectraTable(
-                self.eventid, self.gmrecords.args.label, self.gmrecords.conf
+                self.eventid, self.gmrecords.args.label, config
             )
 
             # We need to have a consistent set of frequencies for reporting the
@@ -68,7 +69,7 @@ class ExportMetricTablesModule(base.SubcommandModule):
             # this could be changed to something else, or even be set via the
             # config file.
             snr_table, snr_readme = self.workspace.getSNRTable(
-                self.eventid, self.gmrecords.args.label, self.gmrecords.conf
+                self.eventid, self.gmrecords.args.label, config
             )
             self.workspace.close()
 

--- a/gmprocess/subcommands/export_shakemap.py
+++ b/gmprocess/subcommands/export_shakemap.py
@@ -11,6 +11,7 @@ base = LazyLoader("base", globals(), "gmprocess.subcommands.base")
 ws = LazyLoader("ws", globals(), "gmprocess.io.asdf.stream_workspace")
 const = LazyLoader("const", globals(), "gmprocess.utils.constants")
 sm_utils = LazyLoader("sm_utils", globals(), "gmprocess.utils.export_shakemap_utils")
+confmod = LazyLoader("confmod", globals(), "gmprocess.utils.config")
 
 
 class ExportShakeMapModule(base.SubcommandModule):
@@ -65,6 +66,10 @@ class ExportShakeMapModule(base.SubcommandModule):
 
             self.workspace = ws.StreamWorkspace.open(workname)
             self._get_labels()
+            if hasattr(self.workspace, "config"):
+                config = self.workspace.config
+            else:
+                config = confmod.get_config()
 
             expanded_imts = self.gmrecords.args.expand_imts
             jsonfile, stationfile, _ = sm_utils.create_json(
@@ -72,7 +77,7 @@ class ExportShakeMapModule(base.SubcommandModule):
                 event,
                 event_dir,
                 self.gmrecords.args.label,
-                config=self.gmrecords.conf,
+                config=config,
                 expanded_imts=expanded_imts,
             )
 

--- a/gmprocess/subcommands/generate_station_maps.py
+++ b/gmprocess/subcommands/generate_station_maps.py
@@ -59,6 +59,7 @@ class GenerateHTMLMapModule(base.SubcommandModule):
                 return False
 
             self._get_labels()
+            config = self.workspace.config
             logging.info(f"Generating station maps for event {event.id}...")
 
             pstreams = []
@@ -67,7 +68,7 @@ class GenerateHTMLMapModule(base.SubcommandModule):
                     event.id,
                     stations=[station_id],
                     labels=[self.gmrecords.args.label],
-                    config=self.gmrecords.conf,
+                    config=config,
                 )
                 if not len(streams):
                     raise ValueError("No matching streams found.")

--- a/gmprocess/subcommands/process_waveforms.py
+++ b/gmprocess/subcommands/process_waveforms.py
@@ -91,7 +91,7 @@ class ProcessWaveformsModule(base.SubcommandModule):
                 event.id,
                 stations=[station_id],
                 labels=["unprocessed"],
-                config=self.gmrecords.conf,
+                config=workspace.config,
             )
 
             if len(raw_streams):
@@ -103,14 +103,12 @@ class ProcessWaveformsModule(base.SubcommandModule):
                         processing.process_streams,
                         raw_streams,
                         event,
-                        self.gmrecords.conf,
+                        workspace.config,
                     )
                     futures.append(future)
                 else:
                     processed_streams.append(
-                        processing.process_streams(
-                            raw_streams, event, self.gmrecords.conf
-                        )
+                        processing.process_streams(raw_streams, event, workspace.config)
                     )
 
         if self.gmrecords.args.num_processes > 0:

--- a/gmprocess/subcommands/process_waveforms.py
+++ b/gmprocess/subcommands/process_waveforms.py
@@ -15,6 +15,7 @@ ws = LazyLoader("ws", globals(), "gmprocess.io.asdf.stream_workspace")
 processing = LazyLoader(
     "processing", globals(), "gmprocess.waveform_processing.processing"
 )
+confmod = LazyLoader("confmod", globals(), "gmprocess.utils.config")
 
 
 class ProcessWaveformsModule(base.SubcommandModule):
@@ -87,11 +88,15 @@ class ProcessWaveformsModule(base.SubcommandModule):
 
         for station_id in station_list:
             # Cannot parallelize IO to ASDF file
+            if hasattr(workspace, "config"):
+                config = workspace.config
+            else:
+                config = confmod.get_config()
             raw_streams = workspace.getStreams(
                 event.id,
                 stations=[station_id],
                 labels=["unprocessed"],
-                config=workspace.config,
+                config=config,
             )
 
             if len(raw_streams):
@@ -103,12 +108,12 @@ class ProcessWaveformsModule(base.SubcommandModule):
                         processing.process_streams,
                         raw_streams,
                         event,
-                        workspace.config,
+                        config,
                     )
                     futures.append(future)
                 else:
                     processed_streams.append(
-                        processing.process_streams(raw_streams, event, workspace.config)
+                        processing.process_streams(raw_streams, event, config)
                     )
 
         if self.gmrecords.args.num_processes > 0:

--- a/gmprocess/utils/assemble_utils.py
+++ b/gmprocess/utils/assemble_utils.py
@@ -67,10 +67,10 @@ def assemble(event, config, directory, gmprocess_version):
     workspace.addEvent(event)
     logging.debug("workspace.dataset.events:")
     logging.debug(workspace.dataset.events)
+    workspace.addConfig(config)
     workspace.addStreams(event, tcollection, label="unprocessed")
     logging.debug("workspace.dataset.waveforms.list():")
     logging.debug(workspace.dataset.waveforms.list())
-    workspace.addConfig()
     workspace.addGmprocessVersion(gmprocess_version)
     logging.debug("workspace.dataset.config")
 

--- a/gmprocess/utils/config.py
+++ b/gmprocess/utils/config.py
@@ -124,9 +124,7 @@ CONF_SCHEMA = Schema(
             },
             "duration": {"intervals": list},
         },
-        "integration": {
-            "method": str
-        },
+        "integration": {"method": str},
         "pickers": {
             "p_arrival_shift": float,
             Optional("ar"): {
@@ -233,6 +231,15 @@ def get_config(config_file=None, section=None):
         IndexError:
             If input section name is not found.
     """
+    print("*" * 80)
+    print("get_config")
+    import inspect
+
+    curframe = inspect.currentframe()
+    calframe = inspect.getouterframes(curframe, 2)
+    print(calframe[1][3])
+    print("*" * 80)
+
     if config_file is None:
         # Try not to let tests interfere with actual system:
         if os.getenv("CALLED_FROM_PYTEST") is None:

--- a/gmprocess/utils/config.py
+++ b/gmprocess/utils/config.py
@@ -231,15 +231,6 @@ def get_config(config_file=None, section=None):
         IndexError:
             If input section name is not found.
     """
-    print("*" * 80)
-    print("get_config")
-    import inspect
-
-    curframe = inspect.currentframe()
-    calframe = inspect.getouterframes(curframe, 2)
-    print(calframe[1][3])
-    print("*" * 80)
-
     if config_file is None:
         # Try not to let tests interfere with actual system:
         if os.getenv("CALLED_FROM_PYTEST") is None:

--- a/gmprocess/utils/plot.py
+++ b/gmprocess/utils/plot.py
@@ -567,7 +567,7 @@ def plot_moveout(
     return (fig, ax)
 
 
-def summary_plots(st, directory, origin):
+def summary_plots(st, directory, origin, config=None):
     """Stream summary plot.
 
     Args:
@@ -577,10 +577,14 @@ def summary_plots(st, directory, origin):
             Directory for saving plots.
         origin (ScalarEvent):
             Flattened subclass of Obspy Event.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
+
     """
     mpl.rcParams["font.size"] = 8
 
-    config = get_config()
+    if config is None:
+        config = get_config()
 
     # Check if directory exists, and if not, create it.
     if not os.path.exists(directory):
@@ -613,13 +617,13 @@ def summary_plots(st, directory, origin):
     # Compute velocity
     st_vel = st.copy()
     for tr in st_vel:
-        tr.data = get_vel(tr,method = config["integration"]["method"])
+        tr.data = get_vel(tr, method=config["integration"]["method"])
 
     # Compute displacement
     st_dis = st.copy()
     for tr in st_dis:
-        tr.data = get_disp(tr,method = config["integration"]["method"])
-    
+        tr.data = get_disp(tr, method=config["integration"]["method"])
+
     # process channels in preferred sort order (i.e., HN1, HN2, HNZ)
     channels = [tr.stats.channel for tr in st]
     if len(channels) < 3:

--- a/gmprocess/waveform_processing/PolynomialFit_SJB.py
+++ b/gmprocess/waveform_processing/PolynomialFit_SJB.py
@@ -6,10 +6,6 @@ import logging
 from scipy import signal
 from gmprocess.utils.config import get_config
 from gmprocess.waveform_processing.integrate import get_disp
-from gmprocess.waveform_processing.filtering import (
-    lowpass_filter_trace,
-    highpass_filter_trace,
-)
 
 
 def PolynomialFit_SJB(
@@ -28,7 +24,8 @@ def PolynomialFit_SJB(
         st (StationStream):
             Stream of data.
         target (float):
-            target percentage for ratio between max polynomial value and max displacement.
+            target percentage for ratio between max polynomial value and max
+            displacement.
         tol (float):
             tolereance for matching the ratio target
         polynomial_order (float):
@@ -38,14 +35,18 @@ def PolynomialFit_SJB(
         maxfc (float):
             Maximum allowable value of the highpass corner freq.
         int_method (string):
-            method used to perform integration between acceleration, velocity, and dispacement. Options are "frequency_domain", "time_domain_zero_init" or "time_domain_zero_mean"
+            method used to perform integration between acceleration, velocity, and
+            dispacement. Options are "frequency_domain", "time_domain_zero_init" or
+            "time_domain_zero_mean"
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream.
 
     """
-    config = get_config()
-    int_method = config["integration"]
+    if config is None:
+        config = get_config()
 
     for tr in st:
         if not tr.hasParameter("corner_frequencies"):
@@ -104,7 +105,6 @@ def __ridder_log(
     Facc = np.fft.rfft(acc, n=len(acc))
     freq = np.fft.rfftfreq(len(acc), acc.stats.delta)
     fc0 = f_hp
-    Facc0 = Facc
     disp0 = get_disp(acc, method=int_config["method"])
     R0 = get_residual(time, disp0, target, polynomial_order)
 

--- a/gmprocess/waveform_processing/PolynomialFit_SJB.py
+++ b/gmprocess/waveform_processing/PolynomialFit_SJB.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import logging
-from scipy import signal
 from gmprocess.utils.config import get_config
 from gmprocess.waveform_processing.integrate import get_disp
 
@@ -11,10 +10,11 @@ from gmprocess.waveform_processing.integrate import get_disp
 def PolynomialFit_SJB(
     st, target=0.02, tol=0.001, polynomial_order=6.0, maxiter=30, maxfc=0.5, config=None
 ):
-    """Search for highpass corner using Ridder's method such that
-        it satisfies the criterion that the ratio between the maximum of a third order polynomial
-        fit to the displacement time series and the maximum of the displacement
-        timeseries is a target % within a tolerance.
+    """Search for highpass corner using Ridder's method.
+
+    Search such that the criterion that the ratio between the maximum of a third order
+    polynomial fit to the displacement time series and the maximum of the displacement
+    timeseries is a target % within a tolerance.
 
     This algorithm searches between a low initial corner frequency a maximum fc.
 
@@ -71,7 +71,8 @@ def PolynomialFit_SJB(
 
             else:
                 tr.fail(
-                    "Initial Ridder residuals were both positive, cannot find appropriate fchp below maxfc"
+                    "Initial Ridder residuals were both positive, cannot find "
+                    "appropriate fchp below maxfc."
                 )
 
     return st
@@ -116,7 +117,13 @@ def __ridder_log(
 
     R2 = get_residual(time, disp2, target, polynomial_order)
     if (np.sign(R0) < 0) and (np.sign(R2) < 0):
-        # output = {'status': True, 'fc (Hz)': fc0, 'acc (g)': np.fft.irfft(Facc0), 'vel (m/s)': get_vel(freq, Facc0), 'disp (m)': get_disp(freq, Facc0)}
+        # output = {
+        #     'status': True,
+        #     'fc (Hz)': fc0,
+        #     'acc (g)': np.fft.irfft(Facc0),
+        #     'vel (m/s)': get_vel(freq, Facc0),
+        #     'disp (m)': get_disp(freq, Facc0)
+        # }
         output = [True, fc0, np.abs(R0)]
         return output
     if (np.sign(R0) > 0) and (np.sign(R2) > 0):

--- a/gmprocess/waveform_processing/adjust_highpass.py
+++ b/gmprocess/waveform_processing/adjust_highpass.py
@@ -4,7 +4,6 @@
 import numpy as np
 
 from gmprocess.utils.config import get_config
-from scipy.optimize import curve_fit
 from gmprocess.waveform_processing.filtering import (
     lowpass_filter_trace,
     highpass_filter_trace,
@@ -19,6 +18,7 @@ def adjust_highpass_corner(
     maximum_freq=0.5,
     max_final_displacement=0.2,
     max_displacment_ratio=0.2,
+    config=None,
 ):
     """Adjust high pass corner frequency.
 
@@ -47,6 +47,8 @@ def adjust_highpass_corner(
             Maximum allowable value (in cm) for final displacement.
         max_displacment_ratio (float):
             Maximum allowable ratio of final displacement to max displacment.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream.

--- a/gmprocess/waveform_processing/adjust_highpass.py
+++ b/gmprocess/waveform_processing/adjust_highpass.py
@@ -64,7 +64,9 @@ def adjust_highpass_corner(
         else:
             initial_corners = tr.getParameter("corner_frequencies")
             f_hp = initial_corners["highpass"]
-            ok = __disp_checks(tr, max_final_displacement, max_displacment_ratio)
+            ok = __disp_checks(
+                tr, max_final_displacement, max_displacment_ratio, config
+            )
             while not ok:
                 f_hp = step_factor * f_hp
                 if f_hp > maximum_freq:
@@ -75,14 +77,19 @@ def adjust_highpass_corner(
                     break
                 initial_corners["highpass"] = f_hp
                 tr.setParameter("corner_frequencies", initial_corners)
-                ok = __disp_checks(tr, max_final_displacement, max_displacment_ratio)
+                ok = __disp_checks(
+                    tr, max_final_displacement, max_displacment_ratio, config
+                )
     return st
 
 
-def __disp_checks(tr, max_final_displacement=0.025, max_displacment_ratio=0.2):
+def __disp_checks(
+    tr, max_final_displacement=0.025, max_displacment_ratio=0.2, config=None
+):
     # Need to find the high/low pass filtering steps in the config
     # to ensure that filtering here is done with the same options
-    config = get_config()
+    if config is None:
+        config = get_config()
     processing_steps = config["processing"]
     ps_names = [list(ps.keys())[0] for ps in processing_steps]
     ind = int(np.where(np.array(ps_names) == "highpass_filter")[0][0])
@@ -99,7 +106,7 @@ def __disp_checks(tr, max_final_displacement=0.025, max_displacment_ratio=0.2):
     trdis = highpass_filter_trace(trdis, **hp_args)
 
     # Apply baseline correction
-    trdis = correct_baseline(trdis)
+    trdis = correct_baseline(trdis, config)
 
     # Integrate to displacment
     trdis = get_disp(trdis, method=config["integration"]["method"])

--- a/gmprocess/waveform_processing/baseline_correction.py
+++ b/gmprocess/waveform_processing/baseline_correction.py
@@ -8,7 +8,7 @@ from gmprocess.waveform_processing.integrate import get_disp
 from gmprocess.utils.config import get_config
 
 
-def correct_baseline(trace):
+def correct_baseline(trace, config=None):
     """
     Performs a baseline correction following the method of Ancheta
     et al. (2013). This removes low-frequency, non-physical trends
@@ -17,11 +17,14 @@ def correct_baseline(trace):
     Args:
         trace (obspy.core.trace.Trace):
             Trace of strong motion data.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         trace: Baseline-corrected trace.
     """
-    config = get_config()
+    if config is None:
+        config = get_config()
 
     # Integrate twice to get the displacement time series
     disp_data = get_disp(trace, method=config["integration"]["method"])

--- a/gmprocess/waveform_processing/baseline_correction.py
+++ b/gmprocess/waveform_processing/baseline_correction.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
 import numpy as np
 from scipy.optimize import curve_fit
 from gmprocess.waveform_processing.integrate import get_disp

--- a/gmprocess/waveform_processing/clipping/clipping_check.py
+++ b/gmprocess/waveform_processing/clipping/clipping_check.py
@@ -13,7 +13,7 @@ from gmprocess.waveform_processing.clipping.ping import Ping
 M_TO_KM = 1.0 / 1000
 
 
-def check_clipping(st, origin, threshold=0.2):
+def check_clipping(st, origin, threshold=0.2, config=None):
     """Apply clicking check.
 
     Lower thresholds will pass fewer streams but will give less false negatives
@@ -26,6 +26,8 @@ def check_clipping(st, origin, threshold=0.2):
             ScalarEvent object.
         threshold (float):
             Threshold probability.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream checked for clipping.

--- a/gmprocess/waveform_processing/filtering.py
+++ b/gmprocess/waveform_processing/filtering.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
-def highpass_filter(st, filter_order=5, number_of_passes=2):
+def highpass_filter(st, filter_order=5, number_of_passes=2, config=None):
     """
     Highpass filter.
 
@@ -13,6 +13,8 @@ def highpass_filter(st, filter_order=5, number_of_passes=2):
             Filter order.
         number_of_passes (int):
             Number of passes.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream: Filtered streams.
@@ -66,7 +68,7 @@ def highpass_filter_trace(tr, filter_order=5, number_of_passes=2):
     return tr
 
 
-def lowpass_filter(st, filter_order=5, number_of_passes=2):
+def lowpass_filter(st, filter_order=5, number_of_passes=2, config=None):
     """
     Lowpass filter.
 
@@ -77,6 +79,8 @@ def lowpass_filter(st, filter_order=5, number_of_passes=2):
             Filter order.
         number_of_passes (int):
             Number of passes.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream: Filtered streams.

--- a/gmprocess/waveform_processing/integrate.py
+++ b/gmprocess/waveform_processing/integrate.py
@@ -2,21 +2,19 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-
 from scipy.integrate import cumtrapz
-from gmprocess.utils.config import get_config
 
 
 def get_disp(tr, method="frequency_domain"):
-
-    """Integrate acceleration to displacement using the method chosen in the config file.
+    """Integrate acceleration to displacement.
 
     Args:
-    tr (StationTrace):
-        Trace of acceleration data. This is the trace where the Cache values will be set.
-    method (string):
-        method used to perform integration, specified in the config file.
-        Options are "frequency_domain", "time_domain_0init" or "time_domain_0init_0mean"
+        tr (StationTrace):
+            Trace of acceleration data. This is the trace where the Cache values will
+            be set.
+        method (string):
+            Method used to perform integration. Options are "frequency_domain",
+            "time_domain_0init" or "time_domain_0init_0mean".
 
     Returns:
         StationTrace.
@@ -56,20 +54,22 @@ def get_disp(tr, method="frequency_domain"):
         return disp
     else:
         raise ValueError(
-            "Improper integration method specified in config. Must be one of 'frequency_domain', 'time_domain_0init' or 'time_domain_0init_0mean'"
+            "Improper integration method specified in config. "
+            "Must be one of 'frequency_domain', 'time_domain_0init' or "
+            "'time_domain_0init_0mean'"
         )
 
 
 def get_vel(tr, method="frequency_domain"):
-
-    """Integrate acceleration to velocity using the method chosen in the config file.
+    """Integrate acceleration to velocity.
 
     Args:
-    tr (StationTrace):
-        Trace of acceleration data. This is the trace where the Cache values will be set.
-    method (string):
-        method used to perform integration, specified in the config file.
-        Options are "frequency_domain", "time_domain_0init" or "time_domain_0init_0mean"
+        tr (StationTrace):
+            Trace of acceleration data. This is the trace where the Cache values will
+            be set.
+        method (string):
+            Method used to perform integration, specified in the config file. Options
+            are "frequency_domain", "time_domain_0init" or "time_domain_0init_0mean".
 
     Returns:
         StationTrace.
@@ -102,5 +102,6 @@ def get_vel(tr, method="frequency_domain"):
         return vel
     else:
         raise ValueError(
-            "Improper integration method specified in config. Must be one of 'frequency_domain', 'time_domain_0init' or 'time_domain_0init_0mean'"
+            "Improper integration method specified in config. Must be one of "
+            "'frequency_domain', 'time_domain_0init' or 'time_domain_0init_0mean'"
         )

--- a/gmprocess/waveform_processing/integrate.py
+++ b/gmprocess/waveform_processing/integrate.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import logging
 
 from scipy.integrate import cumtrapz
 from gmprocess.utils.config import get_config

--- a/gmprocess/waveform_processing/nn_quality_assurance.py
+++ b/gmprocess/waveform_processing/nn_quality_assurance.py
@@ -873,7 +873,7 @@ def computeQualityMetrics(st):
     return qm
 
 
-def NNet_QA(st, acceptance_threshold, model_name):
+def NNet_QA(st, acceptance_threshold, model_name, config=None):
     """
     Assess the quality of a stream by analyzing its two horizontal components
     as described in Bellagamba et al. (2019). Performs three steps:
@@ -895,6 +895,8 @@ def NNet_QA(st, acceptance_threshold, model_name):
             Threshold from which GM records are considered acceptable.
         model_name (string):
             name of the used model ('Cant' or 'CantWell')
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         st: stream of traces tagged with quality scores and flags,

--- a/gmprocess/waveform_processing/pretesting.py
+++ b/gmprocess/waveform_processing/pretesting.py
@@ -8,7 +8,7 @@ Pretesting methods.
 from obspy.signal.trigger import classic_sta_lta
 
 
-def check_free_field(st, reject_non_free_field=False):
+def check_free_field(st, reject_non_free_field=False, config=None):
     """
     Checks free field status of stream.
 
@@ -17,6 +17,8 @@ def check_free_field(st, reject_non_free_field=False):
             Stream of data.
         reject_non_free_field (bool):
             Should non free-field stations be failed?
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         Stream that has been checked for free field status.
@@ -31,7 +33,7 @@ def check_free_field(st, reject_non_free_field=False):
     return st
 
 
-def check_sta_lta(st, sta_length=1.0, lta_length=20.0, threshold=5.0):
+def check_sta_lta(st, sta_length=1.0, lta_length=20.0, threshold=5.0, config=None):
     """
     Checks that the maximum STA/LTA ratio for AT LEAST ONE of the stream's
     traces is above a certain threshold.
@@ -45,6 +47,8 @@ def check_sta_lta(st, sta_length=1.0, lta_length=20.0, threshold=5.0):
             Length of time window for LTA (seconds).
         threshold (float):
             Required maximum STA/LTA ratio to pass the test.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         Stream that has been checked for sta/lta requirements.
@@ -70,7 +74,7 @@ def check_sta_lta(st, sta_length=1.0, lta_length=20.0, threshold=5.0):
     return st
 
 
-def check_max_amplitude(st, min=5, max=2e6):
+def check_max_amplitude(st, min=5, max=2e6, config=None):
     """
     Checks that the maximum amplitude of the traces in the stream are ALL
     within a defined range. Only applied to counts/raw data.
@@ -82,6 +86,8 @@ def check_max_amplitude(st, min=5, max=2e6):
             Minimum amplitude for the acceptable range. Default is 5.
         max (float):
             Maximum amplitude for the acceptable range. Default is 2e6.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         Stream that has been checked for maximum amplitude criteria.

--- a/gmprocess/waveform_processing/processing.py
+++ b/gmprocess/waveform_processing/processing.py
@@ -457,9 +457,9 @@ def detrend(st, detrending_method=None, config=None):
 
     for tr in st:
         if detrending_method == "baseline_sixth_order":
-            tr = correct_baseline(tr)
+            tr = correct_baseline(tr, config)
         elif detrending_method == "pre":
-            tr = _detrend_pre_event_mean(tr)
+            tr = _detrend_pre_event_mean(tr, config)
         else:
             tr = tr.detrend(detrending_method)
 
@@ -669,13 +669,15 @@ def max_traces(st, n_max=3, config=None):
     return st
 
 
-def _detrend_pre_event_mean(trace):
+def _detrend_pre_event_mean(trace, config=None):
     """
     Subtraces the mean of the pre-event noise window from the full trace.
 
     Args:
         trace (obspy.core.trace.Trace):
             Trace of strong motion data.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         trace: Detrended trace.

--- a/gmprocess/waveform_processing/processing.py
+++ b/gmprocess/waveform_processing/processing.py
@@ -179,9 +179,9 @@ def process_streams(streams, origin, config=None):
                 step_args["mag"] = origin.magnitude
 
             if step_args is None:
-                stream = globals()[step_name](stream)
+                stream = globals()[step_name](stream, config)
             else:
-                stream = globals()[step_name](stream, **step_args)
+                stream = globals()[step_name](stream, **step_args, config=config)
 
     # -------------------------------------------------------------------------
     # Begin colocated instrument selection
@@ -196,7 +196,9 @@ def process_streams(streams, origin, config=None):
     return streams
 
 
-def remove_response(st, f1, f2, f3=None, f4=None, water_level=None, inv=None):
+def remove_response(
+    st, f1, f2, f3=None, f4=None, water_level=None, inv=None, config=None
+):
     """
     Performs instrument response correction. If the response information is
     not already attached to the stream, then an inventory object must be
@@ -221,6 +223,8 @@ def remove_response(st, f1, f2, f3=None, f4=None, water_level=None, inv=None):
             Water level for deconvolution.
         inv (obspy.core.inventory.inventory):
             Obspy inventory object containing response information.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream: Instrument-response-corrected stream.
@@ -370,7 +374,7 @@ def remove_response(st, f1, f2, f3=None, f4=None, water_level=None, inv=None):
     return st
 
 
-def lowpass_max_frequency(st, fn_fac=0.9):
+def lowpass_max_frequency(st, fn_fac=0.9, config=None):
     """
     Cap lowpass corner as a fraction of the Nyquist.
 
@@ -379,6 +383,8 @@ def lowpass_max_frequency(st, fn_fac=0.9):
             Stream of data.
         fn_fac (float):
             Factor to be multiplied by the Nyquist to cap the lowpass filter.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream: Resampled stream.
@@ -397,7 +403,7 @@ def lowpass_max_frequency(st, fn_fac=0.9):
     return st
 
 
-def min_sample_rate(st, min_sps=20.0):
+def min_sample_rate(st, min_sps=20.0, config=None):
     """
     Discard records if the sample rate doers not exceed minimum.
 
@@ -406,6 +412,8 @@ def min_sample_rate(st, min_sps=20.0):
             Stream of data.
         min_sps (float):
             Minimum samples per second.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream: Stream checked for sample rate criteria.
@@ -421,7 +429,7 @@ def min_sample_rate(st, min_sps=20.0):
     return st
 
 
-def detrend(st, detrending_method=None):
+def detrend(st, detrending_method=None, config=None):
     """
     Detrend stream.
 
@@ -437,6 +445,8 @@ def detrend(st, detrending_method=None):
                    fit polynomial is then removed from the acceleration time
                    series.
                 - 'pre', for removing the mean of the pre-event noise window.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream: Detrended stream.
@@ -458,7 +468,7 @@ def detrend(st, detrending_method=None):
     return st
 
 
-def resample(st, new_sampling_rate=None, method=None, a=None):
+def resample(st, new_sampling_rate=None, method=None, a=None, config=None):
     """
     Resample stream.
 
@@ -471,6 +481,8 @@ def resample(st, new_sampling_rate=None, method=None, a=None):
             Method for interpolation. Currently only supports 'lanczos'.
         a (int):
             Width of the Lanczos window, in number of samples.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream: Resampled stream.
@@ -488,7 +500,7 @@ def resample(st, new_sampling_rate=None, method=None, a=None):
     return st
 
 
-def get_corner_frequencies(st, method="constant", constant=None, snr=None):
+def get_corner_frequencies(st, method="constant", constant=None, snr=None, config=None):
     """
     Select corner frequencies.
 
@@ -501,6 +513,8 @@ def get_corner_frequencies(st, method="constant", constant=None, snr=None):
             Dictionary of `constant` method config options.
         snr (dict):
             Dictionary of `snr` method config options.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         strea: Stream with selected corner frequencies added.
@@ -536,7 +550,7 @@ def get_corner_frequencies(st, method="constant", constant=None, snr=None):
     return st
 
 
-def taper(st, type="hann", width=0.05, side="both"):
+def taper(st, type="hann", width=0.05, side="both", config=None):
     """
     Taper streams.
 
@@ -549,6 +563,8 @@ def taper(st, type="hann", width=0.05, side="both"):
             Taper width as percentage of trace length.
         side (str):
             Valid options: "both", "left", "right".
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         stream: tapered streams.
@@ -565,7 +581,7 @@ def taper(st, type="hann", width=0.05, side="both"):
     return st
 
 
-def check_instrument(st, n_max=3, n_min=1, require_two_horiz=False):
+def check_instrument(st, n_max=3, n_min=1, require_two_horiz=False, config=None):
     """
     Test the channels of the station.
 
@@ -586,12 +602,17 @@ def check_instrument(st, n_max=3, n_min=1, require_two_horiz=False):
             Minimum allowed number of streams; default to 1.
         require_two_horiz (bool):
             Require two horizontal components; default to `False`.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         Stream with adjusted failed fields.
     """
     if not st.passed:
         return st
+
+    if config is None:
+        config = get_config()
 
     logging.debug("Starting check_instrument")
     logging.debug(f"len(st) = {len(st)}")
@@ -613,7 +634,7 @@ def check_instrument(st, n_max=3, n_min=1, require_two_horiz=False):
     return st
 
 
-def max_traces(st, n_max=3):
+def max_traces(st, n_max=3, config=None):
     """
     Reject a stream if it has more than n_max traces.
 
@@ -626,6 +647,8 @@ def max_traces(st, n_max=3):
             Stream of data.
         n_max (int):
             Maximum allowed number of streams; default to 3.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         Stream with adjusted failed fields.

--- a/gmprocess/waveform_processing/sanity_checks.py
+++ b/gmprocess/waveform_processing/sanity_checks.py
@@ -55,7 +55,8 @@ def check_tail(st, duration, max_vel_ratio=0.1, max_dis_ratio=0.5, config=None):
             )
         return st
 
-    config = get_config()
+    if config is None:
+        config = get_config()
 
     vel = st.copy()
     dis = st.copy()

--- a/gmprocess/waveform_processing/sanity_checks.py
+++ b/gmprocess/waveform_processing/sanity_checks.py
@@ -11,7 +11,7 @@ from gmprocess.waveform_processing.integrate import get_disp
 from gmprocess.utils.config import get_config
 
 
-def check_tail(st, duration, max_vel_ratio=0.1, max_dis_ratio=0.5):
+def check_tail(st, duration, max_vel_ratio=0.1, max_dis_ratio=0.5, config=None):
     """Check for abnormally arge values in the tail of the stream.
 
     This QA check looks for the presence of abnomally large values in the tail
@@ -35,6 +35,8 @@ def check_tail(st, duration, max_vel_ratio=0.1, max_dis_ratio=0.5):
             Trace is labeled as failed if the max absolute displacement in the
             tail is greater than max_disp_ratio times the max absolute
             displacement of the whole trace.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
 

--- a/gmprocess/waveform_processing/snr.py
+++ b/gmprocess/waveform_processing/snr.py
@@ -97,7 +97,7 @@ def compute_snr_trace(tr, bandwidth, mag=None, check=None):
     return tr
 
 
-def compute_snr(st, bandwidth, mag=None, check=None):
+def compute_snr(st, bandwidth, mag=None, check=None, config=None):
     """Compute SNR dictionaries for a stream, looping over all traces.
 
     Args:
@@ -107,6 +107,8 @@ def compute_snr(st, bandwidth, mag=None, check=None):
            Konno-Omachi smoothing bandwidth parameter.
         check (dict):
             If None, no checks performed.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream with SNR dictionaries added as trace parameters.

--- a/gmprocess/waveform_processing/spectrum.py
+++ b/gmprocess/waveform_processing/spectrum.py
@@ -27,6 +27,7 @@ def fit_spectra(
     moment_factor=100,
     min_stress=0.1,
     max_stress=10000,
+    config=None,
 ):
     """
     Fit spectra vaying stress_drop and moment.
@@ -62,6 +63,8 @@ def fit_spectra(
             Min stress for fit search (bars).
         max_stress (float):
             Max stress for fit search (bars).
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         StationStream with fitted spectra parameters.

--- a/gmprocess/waveform_processing/windows.py
+++ b/gmprocess/waveform_processing/windows.py
@@ -29,7 +29,7 @@ from gmprocess.utils.models import load_model
 M_TO_KM = 1.0 / 1000
 
 
-def cut(st, sec_before_split=None):
+def cut(st, sec_before_split=None, config=None):
     """
     Cut/trim the record.
 
@@ -50,6 +50,8 @@ def cut(st, sec_before_split=None):
         sec_before_split (float):
             Seconds to trim before split. If None, then the beginning of the
             record will be unchanged.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
 
     Returns:
         stream: cut streams.

--- a/gmprocess/waveform_processing/zero_crossings.py
+++ b/gmprocess/waveform_processing/zero_crossings.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 
-def check_zero_crossings(st, min_crossings=1.0):
+def check_zero_crossings(st, min_crossings=1.0, config=None):
     """
     Check for a large enough density.
 
@@ -18,6 +18,10 @@ def check_zero_crossings(st, min_crossings=1.0):
         min_crossings (float):
             Minimum average number of zero crossings per second for the full
             trace.
+        config (dict):
+            Configuration dictionary (or None). See get_config().
+
+
     """
 
     zero_count_tr = []

--- a/tests/gmprocess/waveform_processing/integrate_test.py
+++ b/tests/gmprocess/waveform_processing/integrate_test.py
@@ -12,13 +12,14 @@ from gmprocess.waveform_processing.integrate import get_disp, get_vel
 def test_get_disp():
 
     data_files, origin = read_data_dir("geonet", "us1000778i", "*.V1A")
+    data_files.sort()
     streams = []
     for f in data_files:
         streams += read_data(f)
 
     sc = StreamCollection(streams)
-    final_disp = []
 
+    final_disp = []
     for st in sc:
         for tr in st:
             tmp_tr = get_disp(tr, method="frequency_domain")
@@ -26,12 +27,12 @@ def test_get_disp():
 
     target_final_disp = np.array(
         [
-            1.4240303493834734,
-            19.964467165802507,
-            -0.7295398519335637,
             445.4408510389776,
             -564.5331627429107,
             95.93129050746522,
+            1.4240303493834734,
+            19.964467165802507,
+            -0.7295398519335637,
             22.681473557944386,
             5.625360774241337,
             0.9082835404390465,
@@ -40,16 +41,39 @@ def test_get_disp():
 
     np.testing.assert_allclose(final_disp, target_final_disp, atol=1e-6)
 
+    final_disp = []
+    for st in sc:
+        for tr in st:
+            tmp_tr = get_disp(tr, method="time_domain_0init_0mean")
+            final_disp.append(tmp_tr.data[-1])
+
+    target_final_disp = np.array(
+        [
+            -0.0639925584433825,
+            0.06627463001467013,
+            -0.023058193802552758,
+            -0.0008089997861234907,
+            -9.796049089918281e-05,
+            -0.00020812839307250862,
+            -0.0020863824158712813,
+            6.607075292134614e-05,
+            -7.619236969690053e-05,
+        ]
+    )
+
+    np.testing.assert_allclose(final_disp, target_final_disp, atol=1e-6)
+
 
 def test_get_vel():
     data_files, origin = read_data_dir("geonet", "us1000778i", "*.V1A")
+    data_files.sort()
     streams = []
     for f in data_files:
         streams += read_data(f)
 
     sc = StreamCollection(streams)
-    final_vel = []
 
+    final_vel = []
     for st in sc:
         for tr in st:
             tmp_tr = get_vel(tr, method="frequency_domain")
@@ -57,12 +81,12 @@ def test_get_vel():
 
     target_final_vel = np.array(
         [
-            0.09343952407331428,
-            0.05247204800310405,
-            0.03024022273800924,
             15.375974647780472,
             -16.510746211468536,
             4.903137112699634,
+            0.09343952407331428,
+            0.05247204800310405,
+            0.03024022273800924,
             0.6851275446327221,
             -0.13432774959189756,
             -0.03563143746678422,


### PR DESCRIPTION
- avoid read/validate the projects conf for "projects" subcommand because this raises annoying exceptions that can be really confusing
- fix unit test that fails on windows due to reading files in a different order
- add config argument to each processing step so that it is received from parent methods rather than being read in every time from the file system and have the config argument passed down to any methods that need it
- added setConfig method to streamworkspace and modified code to make use of this for accessing the config rather than reading it from the file system each time