### PR TITLE
Fix integration method in adjust_highpass method.

### DIFF
--- a/gmprocess/waveform_processing/adjust_highpass.py
+++ b/gmprocess/waveform_processing/adjust_highpass.py
@@ -109,7 +109,7 @@ def __disp_checks(
     trdis = correct_baseline(trdis, config)
 
     # Integrate to displacment
-    trdis = get_disp(trdis, method=config["integration"]["method"])
+    trdis = get_disp(trdis, config=config)
 
     # Checks
     ok = True


### PR DESCRIPTION
When adjust_highpass method is uncommented in the config file, the integration method used is not updated to the new scheme. This updates the integration method to match the previous changes. 