### PR TITLE
Proposed fix for cleaning up logging

### DIFF
--- a/gmprocess/apps/gmrecords.py
+++ b/gmprocess/apps/gmrecords.py
@@ -77,7 +77,7 @@ class GMrecordsApp(object):
             self.parser.print_help()
         else:
             exclude_subcommands = ["projects", "proj", "init"]
-            if self.args.subcommand not in exclude_subcommands:
+            if self.args.subcommand not in exclude_subcommands and not self.args.quiet:
                 # Print the current project information to try to avoid
                 # confusion
                 selected_project = self.projects_conf["project"]
@@ -132,7 +132,7 @@ class GMrecordsApp(object):
         self._load_config()
 
         log_file = self.args.log or None
-        if log_file:
+        if log_file and not self.args.quiet:
             print(f"Logging output sent to: {log_file}")
         log_utils.setup_logger(self.args, log_file=log_file)
         logging.info("Logging level includes INFO.")

--- a/gmprocess/apps/gmrecords.py
+++ b/gmprocess/apps/gmrecords.py
@@ -130,10 +130,9 @@ class GMrecordsApp(object):
         
     def _initialize(self):
         self._load_config()
-        
-        log_file = None
-        if self.args.log:
-            log_file = os.path.join(self.data_path, "log.txt")
+
+        log_file = self.args.log or None
+        if log_file:
             print(f"Logging output sent to: {log_file}")
         log_utils.setup_logger(self.args, log_file=log_file)
         logging.info("Logging level includes INFO.")
@@ -274,8 +273,9 @@ class GMrecordsApp(object):
         self.parser.add_argument(
             "-l",
             "--log",
-            action="store_true",
-            default=False,
+            action="store",
+            type=str,
+            default=None,
             help="Log all output to a file in the project data directory.",
         )
 

--- a/gmprocess/core/streamarray.py
+++ b/gmprocess/core/streamarray.py
@@ -60,11 +60,12 @@ class StreamArray(object):
 
     def describe(self):
         """More verbose description of StreamArray."""
-        summary = ""
-        summary += str(len(self.streams)) + " StationStreams(s) in StreamArray:\n"
+        lines = []
+        lines += [""]
+        lines += [str(len(self.streams)) + " StationStreams(s) in StreamArray:"]
         for stream in self:
-            summary += stream.__str__(indent=INDENT) + "\n"
-        print(summary)
+            lines += [stream.__str__(indent=INDENT)]
+        return "\n".join(lines)
 
     def __len__(self):
         """Number of constituent StationStreams."""

--- a/gmprocess/core/streamcollection.py
+++ b/gmprocess/core/streamcollection.py
@@ -420,11 +420,11 @@ class StreamCollection(StreamArray):
 
     def describe(self):
         """More verbose description of StreamCollection."""
-        summary = ""
-        summary += str(len(self.streams)) + " StationStreams(s) in StreamCollection:\n"
+        lines = [""]
+        lines += [str(len(self.streams)) + " StationStreams(s) in StreamCollection:"]
         for stream in self:
-            summary += stream.__str__(indent=INDENT) + "\n"
-        print(summary)
+            lines += [stream.__str__(indent=INDENT)]
+        return "\n".join(lines)
 
     def __group_by_net_sta_inst(self):
         trace_list = []

--- a/gmprocess/subcommands/assemble.py
+++ b/gmprocess/subcommands/assemble.py
@@ -56,7 +56,7 @@ class AssembleModule(base.SubcommandModule):
                 sys.exit(1)
             futures = client.map(self._assemble_event, self.events)
             for result in distributed.as_completed(futures, with_results=True):
-                print(result)
+                logging.info(result)
             client.shutdown()
         else:
             for event in self.events:

--- a/gmprocess/subcommands/base.py
+++ b/gmprocess/subcommands/base.py
@@ -86,13 +86,13 @@ class SubcommandModule(ABC):
 
     def _summarize_files_created(self):
         if len(self.files_created):
-            print("\nThe following files have been created:")
+            logging.info("The following files have been created:")
             for file_type, file_list in self.files_created.items():
-                print(f"File type: {file_type}")
+                logging.info(f"File type: {file_type}")
                 for fname in file_list:
-                    print(f"\t{os.path.normpath(fname)}")
+                    logging.info(f"\t{os.path.normpath(fname)}")
         else:
-            print("No new files created.")
+            logging.info("No new files created.")
 
     def _get_pstreams(self):
         """Convenience method for recycled code."""

--- a/gmprocess/utils/assemble_utils.py
+++ b/gmprocess/utils/assemble_utils.py
@@ -57,9 +57,8 @@ def assemble(event, config, directory, gmprocess_version):
     else:
         stream_array = StreamArray(streams)
 
-    if len(stream_array):
-        logging.debug("stream_array.describe():")
-        logging.debug(stream_array.describe())
+    logging.info("stream_array.describe():")
+    logging.info(stream_array.describe())
 
     # Create the workspace file and put the unprocessed waveforms in it
     workname = os.path.join(in_event_dir, WORKSPACE_NAME)

--- a/gmprocess/utils/logging.py
+++ b/gmprocess/utils/logging.py
@@ -50,29 +50,27 @@ def setup_logger(args=None, level="info", log_file=None):
     logdict = {
         "version": 1,
         "formatters": {"standard": {"format": fmt, "datefmt": datefmt}},
-        "handlers": {
+        "loggers": {"": {"handlers": [], "level": loglevel, "propagate": True}},
+    }
+    if log_file is None:
+        logdict["handlers"] = {
             "stream": {
                 "level": loglevel,
                 "formatter": "standard",
                 "class": "logging.StreamHandler",
             }
-        },
-        "loggers": {"": {"handlers": ["stream"], "level": loglevel, "propagate": True}},
-    }
-
-    if log_file is not None:
-        logdict["handlers"]["event_file"] = {}
-        logdict["handlers"]["event_file"]["filename"] = log_file
-        if level == "debug":
-            logdict["handlers"]["event_file"]["level"] = logging.DEBUG
-        elif level == "quiet":
-            logdict["handlers"]["event_file"]["level"] = logging.ERROR
-        else:
-            logdict["handlers"]["event_file"]["level"] = logging.INFO
-        logdict["handlers"]["event_file"]["formatter"] = "standard"
-        logdict["handlers"]["event_file"]["class"] = "logging.FileHandler"
-        logdict["loggers"][""]["handlers"] = ["stream", "event_file"]
-
+        }
+        logdict["loggers"][""]["handlers"] = ["stream"]
+    else:
+        logdict["handlers"] = {
+            "event_file": {
+                "filename": log_file,
+                "level": loglevel,
+                "formatter": "standard",
+                "class": "logging.FileHandler",
+            }
+        }
+        logdict["loggers"][""]["handlers"] = ["event_file"]
     logging.config.dictConfig(logdict)
 
     # Have the logger capture anything from the 'warnings' package,


### PR DESCRIPTION
* Turn off logging to stream (stdout) if using log file.
* Replace `print()` with `logging.info()` except for error messages and interaction with user.
* Fix StreamArray and StreamCollection `describe()`
  * Return str instead of print to stdout.
  * Log stream array info regardless of size (formerly only logged if nonzero size).
  * Change logging level for display from `debug` to `info`.

**Note**: Should be merged after #889.

Closes #886