### PR TITLE
wrapper for describe() printing to stdout

### DIFF
--- a/gmprocess/core/streamarray.py
+++ b/gmprocess/core/streamarray.py
@@ -58,7 +58,7 @@ class StreamArray(object):
                     newstreams.append(new_st)
         self.streams = newstreams
 
-    def describe(self):
+    def describe_string(self):
         """More verbose description of StreamArray."""
         lines = []
         lines += [""]

--- a/gmprocess/core/streamarray.py
+++ b/gmprocess/core/streamarray.py
@@ -67,6 +67,11 @@ class StreamArray(object):
             lines += [stream.__str__(indent=INDENT)]
         return "\n".join(lines)
 
+    def describe(self):
+        """Thin wrapper of describe_string() for printing to stdout"""
+        stream_descript  = self.describe_string()
+        print(stream_descript)
+
     def __len__(self):
         """Number of constituent StationStreams."""
         return len(self.streams)

--- a/gmprocess/core/streamcollection.py
+++ b/gmprocess/core/streamcollection.py
@@ -418,13 +418,18 @@ class StreamCollection(StreamArray):
         summary += f"    {self.n_failed} StationStreams(s) failed checks.\n"
         return summary
 
-    def describe(self):
+    def describe_string(self):
         """More verbose description of StreamCollection."""
         lines = [""]
         lines += [str(len(self.streams)) + " StationStreams(s) in StreamCollection:"]
         for stream in self:
             lines += [stream.__str__(indent=INDENT)]
         return "\n".join(lines)
+
+    def describe(self):
+        """Thin wrapper of describe_string() for printing to stdout"""
+        stream_descript  = self.describe_string()
+        print(stream_descript)
 
     def __group_by_net_sta_inst(self):
         trace_list = []

--- a/gmprocess/utils/assemble_utils.py
+++ b/gmprocess/utils/assemble_utils.py
@@ -57,8 +57,8 @@ def assemble(event, config, directory, gmprocess_version):
     else:
         stream_array = StreamArray(streams)
 
-    logging.info("stream_array.describe():")
-    logging.info(stream_array.describe())
+    logging.info("stream_array.describe_string():")
+    logging.info(stream_array.describe_string())
 
     # Create the workspace file and put the unprocessed waveforms in it
     workname = os.path.join(in_event_dir, WORKSPACE_NAME)

--- a/gmprocess/utils/download_utils.py
+++ b/gmprocess/utils/download_utils.py
@@ -58,8 +58,8 @@ def download(event, event_dir, config):
     download_rupture_file(event.id, event_dir)
 
     if len(tcollection):
-        logging.debug("tcollection.describe():")
-        logging.debug(tcollection.describe())
+        logging.debug("tcollection.describe_string():")
+        logging.debug(tcollection.describe_string())
 
     # Plot the raw waveforms
     with warnings.catch_warnings():


### PR DESCRIPTION
Changes the existing `describe()` function, which returns a string literal, to a new function called `describe_string()` for both `StreamCollection` and `StreamArray`.

Another function which now takes the name `describe()` wraps the above and prints to sdtout, allowing for users to see formatted strings