### PR TITLE
Handle failed temp directory deletion

### DIFF
--- a/gmprocess/io/read_directory.py
+++ b/gmprocess/io/read_directory.py
@@ -68,7 +68,11 @@ def directory_to_streams(directory, config=None):
     except BaseException as e:
         raise e
     finally:
-        shutil.rmtree(intermediate_dir)
+        try:
+            shutil.rmtree(intermediate_dir)
+        except OSError:
+            shutil.rmtree(intermediate_dir)
+            
 
     return streams, unprocessed_files, unprocessed_file_errors
 


### PR DESCRIPTION
This is a very kludgy fix of #899 , where `shutil.rmtree` fails to fully remove temporary directories created in `read_directory.py` due to the presence of `.DS_Store` file that is generated if a user looks at the `data/raw/` directory in the Mac OS Finder. 

For reasons that remain inexplicable and will likely join other mysteries such as "What's the meaning of Stonehenge?", despite failing, if `shutil.rmtree` is just re-run on the temp directory, it removes it without error.

If anyone experiences this issue or has some insight into its origin, perhaps we can come up with a more elegant solution.