### PR TITLE
Handle UCLA manual review data in ASDF file

### DIFF
--- a/gmprocess/apps/gmrecords.py
+++ b/gmprocess/apps/gmrecords.py
@@ -330,7 +330,7 @@ class GMrecordsApp(object):
             action="store",
             type=str,
             default=None,
-            help="Log all output to a file in the project data directory.",
+            help="Path to log file; if provided, loging is directed to this file.",
         )
 
         # Parsers for subcommands

--- a/gmprocess/core/stationtrace.py
+++ b/gmprocess/core/stationtrace.py
@@ -9,7 +9,6 @@ from datetime import datetime
 import getpass
 import re
 import inspect
-import csv
 
 # third party imports
 import numpy as np
@@ -19,12 +18,10 @@ import prov.model
 from obspy.core.utcdatetime import UTCDateTime
 import pandas as pd
 from scipy.integrate import cumtrapz
-from obspy.signal.util import next_pow_2
 
 # local imports
 from gmprocess.utils.config import get_config
 from gmprocess.io.seedname import get_units_type
-from gmprocess.waveform_processing.fft import compute_fft
 
 UNITS = {"acc": "cm/s^2", "vel": "cm/s"}
 REVERSE_UNITS = {"cm/s^2": "acc", "cm/s": "vel", "cm": "disp"}
@@ -1099,29 +1096,26 @@ def _get_software_agent(pr, gmprocess_version):
     hashstr = "0000001"
     agent_id = f"seis_prov:sp001_sa_{hashstr}"
     giturl = "https://github.com/usgs/groundmotion-processing"
-    try:
-        pr.agent(
-            agent_id,
-            other_attributes=(
+    pr.agent(
+        agent_id,
+        other_attributes=(
+            (
+                ("prov:label", software),
                 (
-                    ("prov:label", software),
-                    (
-                        "prov:type",
-                        prov.identifier.QualifiedName(
-                            prov.constants.PROV, "SoftwareAgent"
-                        ),
+                    "prov:type",
+                    prov.identifier.QualifiedName(
+                        prov.constants.PROV, "SoftwareAgent"
                     ),
-                    ("seis_prov:software_name", software),
-                    ("seis_prov:software_version", gmprocess_version),
-                    (
-                        "seis_prov:website",
-                        prov.model.Literal(giturl, prov.constants.XSD_ANYURI),
-                    ),
-                )
-            ),
-        )
-    except Exception as e:
-        x = 1
+                ),
+                ("seis_prov:software_name", software),
+                ("seis_prov:software_version", gmprocess_version),
+                (
+                    "seis_prov:website",
+                    prov.model.Literal(giturl, prov.constants.XSD_ANYURI),
+                ),
+            )
+        ),
+    )
     return pr
 
 

--- a/gmprocess/waveform_processing/zero_crossings.py
+++ b/gmprocess/waveform_processing/zero_crossings.py
@@ -33,7 +33,7 @@ def check_zero_crossings(st, min_crossings=1.0, config=None):
         # not want to modify the trace but we only want to count the crossings
         # within the trimmed window
 
-        if tr.hasParameter("signal_end"):
+        if tr.hasParameter("signal_end") and (not tr.hasParameter("failure")):
             etime = tr.getParameter("signal_end")["end_time"]
             split_time = tr.getParameter("signal_split")["split_time"]
 


### PR DESCRIPTION
Closes #896. @meramossepu, please let me know if you run into any issues with this. This pull request adds the `-r` flag for "reprocess" to the `process` subcommand:

```
$ gmrecords process -h
usage: gmrecords process_waveforms [-h] [-e EVENTID [EVENTID ...]] [-t TEXTFILE] [-l LABEL] [-r] [-n n]

optional arguments:
  -h, --help            show this help message and exit
  -e EVENTID [EVENTID ...], --eventid EVENTID [EVENTID ...]
                        Comcat event ID. If None (default) all events in project data directory will be used.
  -t TEXTFILE, --textfile TEXTFILE
                        Text file containing lines of ComCat Event IDs or event information (ID TIME LAT LON DEPTH MAG).
  -l LABEL, --label LABEL
                        Processing label (single word, no spaces) to attach to processed files. Default label is 'default'.
  -r, --reprocess       Reprocess data using manually review information.
  -n n, --num-processes n
                        Number of parallel processes to run over events.
```

My intended workflow is to run the manual review GUI on the ASDF file (located in the event directory), then 
```
gmrecords process -r -e nc73705146
```
This assumes the that you will use the same processing label as was used in the original processing. 
