### PR TITLE
Add freq differentiation option

### DIFF
--- a/gmprocess/data/config_production.yml
+++ b/gmprocess/data/config_production.yml
@@ -609,7 +609,7 @@ integration:
 # -----------------------------------------------------------------------------
 # This section is for options for differentiation
 differentiation:
-    # Frequency or time domain integration?
+    # Frequency or time domain differentation?
     frequency: True
 
 # -----------------------------------------------------------------------------

--- a/gmprocess/data/config_test.yml
+++ b/gmprocess/data/config_test.yml
@@ -579,7 +579,7 @@ integration:
 # -----------------------------------------------------------------------------
 # This section is for options for differentiation
 differentiation:
-    # Frequency or time domain integration?
+    # Frequency or time domain differentation?
     frequency: True
 
 # -----------------------------------------------------------------------------

--- a/gmprocess/metrics/rotation/null_rotation.py
+++ b/gmprocess/metrics/rotation/null_rotation.py
@@ -10,7 +10,7 @@ class Null_Rotation(Rotation):
     other than returning the input rotation_data."""
 
     def __init__(self, rotation_data, event=None):
-        super().__init__(rotation_data, event=None)
+        super().__init__(rotation_data, event=event)
         self.result = self.get_rotation_data()
 
     def get_rotation_data(self):

--- a/gmprocess/metrics/rotation/radial_transverse.py
+++ b/gmprocess/metrics/rotation/radial_transverse.py
@@ -23,8 +23,7 @@ class Radial_Transverse(Rotation):
                 Defines the focal time, geographical location and
                 magnitude of an earthquake hypocenter. Default is None.
         """
-        super().__init__(rotation_data, event=None)
-        self.event = event
+        super().__init__(rotation_data, event=event)
         self.result = self.get_radial_transverse()
 
     def get_radial_transverse(self):

--- a/gmprocess/metrics/rotation/rotation.py
+++ b/gmprocess/metrics/rotation/rotation.py
@@ -21,6 +21,7 @@ class Rotation(object):
                 an earthquake hypocenter. Default is None.
         """
         self.rotation_data = rotation_data
+        self.event = event
 
     def _get_horizontals(self):
         """

--- a/gmprocess/metrics/rotation/rotd.py
+++ b/gmprocess/metrics/rotation/rotd.py
@@ -17,7 +17,7 @@ class Rotd(Rotation):
                 Defines the focal time, geographical location and magnitude of
                 an earthquake hypocenter. Default is None.
         """
-        super().__init__(rotation_data, event=None)
+        super().__init__(rotation_data, event=event)
         self.result = self.get_rotd()
 
     def get_rotd(self):

--- a/gmprocess/metrics/transform/differentiate.py
+++ b/gmprocess/metrics/transform/differentiate.py
@@ -39,13 +39,13 @@ class Differentiate(Transform):
         """
         super().__init__(
             transform_data,
-            damping=None,
-            period=None,
-            times=None,
-            max_period=None,
-            allow_nans=None,
-            bandwidth=None,
-            config=None,
+            damping=damping,
+            period=period,
+            times=times,
+            max_period=max_period,
+            allow_nans=allow_nans,
+            bandwidth=bandwidth,
+            config=config,
         )
         self.result = self.get_derivative()
 
@@ -70,6 +70,9 @@ class Differentiate(Transform):
         """
         stream = StationStream([])
         for trace in self.transform_data:
-            differentiated_trace = trace.copy().differentiate()
+            diff_conf = self.config["differentiation"]
+            differentiated_trace = trace.copy().differentiate(
+                frequency=diff_conf["frequency"]
+            )
             stream.append(differentiated_trace)
         return stream

--- a/gmprocess/metrics/transform/fft.py
+++ b/gmprocess/metrics/transform/fft.py
@@ -46,13 +46,13 @@ class FFT(Transform):
         """
         super().__init__(
             transform_data,
-            damping=None,
-            period=None,
-            times=None,
-            max_period=None,
-            allow_nans=None,
-            bandwidth=None,
-            config=None,
+            damping=damping,
+            period=period,
+            times=times,
+            max_period=max_period,
+            allow_nans=allow_nans,
+            bandwidth=bandwidth,
+            config=config,
         )
         self.max_period = max_period
         self.allow_nans = allow_nans

--- a/gmprocess/metrics/transform/integrate.py
+++ b/gmprocess/metrics/transform/integrate.py
@@ -39,13 +39,13 @@ class Integrate(Transform):
         """
         super().__init__(
             transform_data,
-            damping=None,
-            period=None,
-            times=None,
-            max_period=None,
-            allow_nans=None,
-            bandwidth=None,
-            config=None,
+            damping=damping,
+            period=period,
+            times=times,
+            max_period=max_period,
+            allow_nans=allow_nans,
+            bandwidth=bandwidth,
+            config=config,
         )
         self.result = self.get_integral(config=config)
 

--- a/gmprocess/metrics/transform/null_transform.py
+++ b/gmprocess/metrics/transform/null_transform.py
@@ -22,13 +22,13 @@ class Null_Transform(Transform):
     ):
         super().__init__(
             transform_data,
-            damping=None,
-            period=None,
-            times=None,
-            max_period=None,
-            allow_nans=None,
-            bandwidth=None,
-            config=None,
+            damping=damping,
+            period=period,
+            times=times,
+            max_period=max_period,
+            allow_nans=allow_nans,
+            bandwidth=bandwidth,
+            config=config,
         )
         self.result = self.get_transform_data()
 

--- a/gmprocess/metrics/transform/oscillator.py
+++ b/gmprocess/metrics/transform/oscillator.py
@@ -40,13 +40,13 @@ class oscillator(Transform):
         """
         super().__init__(
             transform_data,
-            damping=None,
-            period=None,
-            times=None,
-            max_period=None,
-            allow_nans=None,
-            bandwidth=None,
-            config=None,
+            damping=damping,
+            period=period,
+            times=times,
+            max_period=max_period,
+            allow_nans=allow_nans,
+            bandwidth=bandwidth,
+            config=config,
         )
         self.period = period
         self.damping = damping

--- a/gmprocess/metrics/transform/transform.py
+++ b/gmprocess/metrics/transform/transform.py
@@ -36,6 +36,7 @@ class Transform(object):
             config (dict):
                 Configuration options.
         """
+        self.config = config
         self.transform_data = transform_data
 
     def _get_horizontals(self):

--- a/gmprocess/waveform_processing/clipping/jerk.py
+++ b/gmprocess/waveform_processing/clipping/jerk.py
@@ -84,8 +84,10 @@ class Jerk(ClipDetection):
                 Is the trace clipped?
         """
         temp_tr = tr.copy()
-        temp_tr.differentiate()
-        temp_tr.differentiate()
+        # The algorithm was developed with time domain differentiation and so we want
+        # to force this to be consistent regardless of config options.
+        temp_tr.differentiate(frequency=False)
+        temp_tr.differentiate(frequency=False)
         abs_diff = np.abs(temp_tr.data)
         median_x100 = 100 * np.median(abs_diff)
         (i_jerk,) = np.where(abs_diff >= median_x100)

--- a/gmprocess/waveform_processing/processing.py
+++ b/gmprocess/waveform_processing/processing.py
@@ -316,15 +316,8 @@ def remove_response(
                             "pre_filt_freqs": f"{f1:f}, {f2:f}, {f3:f}, {f4:f}",
                         },
                     )
-                    tr.differentiate()
-                    tr.setProvenance(
-                        "differentiate",
-                        {
-                            "differentiation_method": "remove_response",
-                            "input_units": ABBREV_UNITS["VEL"],
-                            "output_units": ABBREV_UNITS[output],
-                        },
-                    )
+                    diff_conf = config["differentiation"]
+                    tr.differentiate(frequency=diff_conf["frequency"])
                     tr.data *= M_TO_CM  # Convert from m to cm
                     tr.stats.standard.units = ABBREV_UNITS[output]
                     tr.stats.standard.units_type = output.lower()


### PR DESCRIPTION
Allows you to configure whether or not you want frequency or time domian differentiation. Closes #938. Requires the following new section in the conf file:

```yaml
# -----------------------------------------------------------------------------
# This section is for options for differentiation
differentiation:
    # Frequency or time domain differentiation?
    frequency: True
```
