### PR TITLE
Fix multiple event bug

### DIFF
--- a/gmprocess/io/obspy/fdsn_fetcher.py
+++ b/gmprocess/io/obspy/fdsn_fetcher.py
@@ -218,12 +218,13 @@ class FDSNFetcher(DataFetcher):
                 logging.warning(f"Unable to initalize client {provider_str}")
 
         if len(client_list):
+            for handler in root.handlers:
+                if hasattr(handler, "baseFilename"):
+                    log_file = getattr(handler, "baseFilename")
+            if "log_file" in vars() or "log_file" in globals():
+                sys.stdout = open(log_file, "a")
             # Pass off the initalized clients to the Mass Downloader
             if logging.getLevelName(root.level) == "DEBUG":
-                for handler in root.handlers:
-                    if hasattr(handler, "baseFilename"):
-                        log_file = getattr(handler, "baseFilename")
-                sys.stdout = open(log_file, "a")
                 mdl = MassDownloader(providers=client_list, debug=True)
             else:
                 try:
@@ -239,7 +240,8 @@ class FDSNFetcher(DataFetcher):
             mdl.download(
                 domain, restrictions, mseed_storage=rawdir, stationxml_storage=rawdir
             )
-            sys.stdout.close()
+            if "log_file" in vars() or "log_file" in globals():
+                sys.stdout.close()
 
             if self.stream_collection:
                 seed_files = glob.glob(os.path.join(rawdir, "*.mseed"))

--- a/gmprocess/subcommands/arg_dicts.py
+++ b/gmprocess/subcommands/arg_dicts.py
@@ -52,10 +52,11 @@ ARG_DICTS = {
     "textfile": {
         "short_flag": "-t",
         "long_flag": "--textfile",
-        "help": (
-            "Text file containing lines of ComCat Event IDs or event "
-            "information (ID TIME LAT LON DEPTH MAG)."
-        ),
+        "help": """CSV file containing either: (1) a single column in which that column
+        contains ComCat event IDs, or (2) six columns in which those columns are:
+        id (string, no spaces), time (any ISO standard for date/time), latitutde
+        (float, decimal degrees), longitude (float, decimal degrees), depth (float, km),
+        magnitude (float).""",
         "type": str,
         "default": None,
     },

--- a/gmprocess/subcommands/download.py
+++ b/gmprocess/subcommands/download.py
@@ -3,6 +3,7 @@
 
 import os
 import logging
+import copy
 
 from gmprocess.subcommands.lazy_loader import LazyLoader
 
@@ -56,5 +57,5 @@ class DownloadModule(base.SubcommandModule):
                 os.makedirs(event_dir)
 
             download_utils.download(
-                event=event, event_dir=event_dir, config=gmrecords.conf
+                event=event, event_dir=event_dir, config=copy.deepcopy(gmrecords.conf)
             )

--- a/gmprocess/utils/base_utils.py
+++ b/gmprocess/utils/base_utils.py
@@ -40,7 +40,6 @@ def get_events(eventids, textfile, eventinfo, directory, outdir=None):
 
     """
     events = []
-    breakpoint()
     if eventids is not None:
         # Get list of events from directory if it has been provided
         tevents = []

--- a/gmprocess/utils/base_utils.py
+++ b/gmprocess/utils/base_utils.py
@@ -28,7 +28,6 @@ def get_events(eventids, textfile, eventinfo, directory, outdir=None):
                 - longitude Longitude in decimal degrees.
                 - depth Depth in kilometers.
                 - magnitude Earthquake magnitude.
-                - magnitude_type Earthquake magnitude type.
         directory (str):
             Path to a directory containing event subdirectories, each
             containing an event.json file, where the ID in the json file
@@ -41,6 +40,7 @@ def get_events(eventids, textfile, eventinfo, directory, outdir=None):
 
     """
     events = []
+    breakpoint()
     if eventids is not None:
         # Get list of events from directory if it has been provided
         tevents = []
@@ -134,14 +134,13 @@ def parse_event_file(eventfile):
     Files can contain:
         - one column, in which case that column
           contains ComCat event IDs.
-        - Seven columns, in which case those columns should be:
+        - Six columns, in which case those columns should be:
           - id: any string (no spaces)
           - time: Any ISO standard for date/time.
           - lat: Earthquake latitude in decimal degrees.
           - lon: Earthquake longitude in decimal degrees.
           - depth: Earthquake longitude in kilometers.
           - magnitude: Earthquake magnitude.
-          - magnitude_type: Earthquake magnitude type.
 
     NB: THERE SHOULD NOT BE ANY HEADERS ON THIS FILE!
 
@@ -154,14 +153,14 @@ def parse_event_file(eventfile):
 
     """
     df = pd.read_csv(eventfile, sep=",", header=None)
-    nrows, ncols = df.shape
+    _, ncols = df.shape
     events = []
     if ncols == 1:
         df.columns = ["eventid"]
-        for idx, row in df.iterrows():
+        for _, row in df.iterrows():
             event = get_event_object(row["eventid"])
             events.append(event)
-    elif ncols == 7:
+    elif ncols == 6:
         df.columns = [
             "id",
             "time",
@@ -169,10 +168,9 @@ def parse_event_file(eventfile):
             "lon",
             "depth",
             "magnitude",
-            "magnitude_type",
         ]
         df["time"] = pd.to_datetime(df["time"])
-        for idx, row in df.iterrows():
+        for _, row in df.iterrows():
             rowdict = row.to_dict()
             event = get_event_object(rowdict)
             events.append(event)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pandas>=1.0
 ps2ff>=1.5.2
 pyasdf>=0.7
 pytest>=6.2
+pytest-recording>=0.12
 pytest-cov>=2.12
 pytest-console-scripts>=1.2
 requests>=2.23

--- a/tests/gmprocess/io/obspy/fdsn_fetcher_test.py
+++ b/tests/gmprocess/io/obspy/fdsn_fetcher_test.py
@@ -1,23 +1,58 @@
 #!/usr/bin/env python
 
-from gmprocess.io.obspy.fdsn_fetcher import FDSNFetcher
+import pytest
+import os
 from datetime import datetime
-import os.path
+import tempfile
+import shutil
+
+from gmprocess.utils.config import get_config
+from gmprocess.utils.logging import setup_logger
+from gmprocess.io.obspy.fdsn_fetcher import FDSNFetcher
+
+setup_logger()
 
 
-def fetcher_test():
-    # 2014-08-24 10:20:44
-    eid = "nc72282711"
-    utime = datetime(2014, 8, 24, 10, 20, 44)
-    eqlat = 38.215
-    eqlon = -122.312
-    eqdepth = 11.1
-    eqmag = 6.0
-    rawdir = os.path.join(os.path.expanduser("~"), "tmp", eid, "raw")
-    fetcher = FDSNFetcher(utime, eqlat, eqlon, eqdepth, eqmag, rawdir=rawdir)
-    stream_collection = fetcher.retrieveData()
-    assert len(stream_collection) == 15
+@pytest.fixture(scope="session")
+def vcr_config():
+    # note: set "record_mode" to "once" to record, then set to "none" when prior to
+    # commiting the test. Can also be "rewrite".
+    return {"record_mode": "once", "filter_headers": []}
+
+
+@pytest.mark.vcr
+def skip_test_fetcher():
+    # nc72282711
+    rawdir = tempfile.mkdtemp()
+    try:
+        config = get_config()
+        config["fetchers"]["FDSNFetcher"]["domain"]["circular"]["maxradius"] = 0.1
+        # 2014-08-24 10:20:44
+        utime = datetime(2014, 8, 24, 10, 20, 44)
+        eqlat = 38.215
+        eqlon = -122.312
+        eqdepth = 11.1
+        eqmag = 6.0
+        fetcher = FDSNFetcher(
+            utime,
+            eqlat,
+            eqlon,
+            eqdepth,
+            eqmag,
+            rawdir=rawdir,
+            config=config,
+            stream_collection=False,
+        )
+        fetcher.retrieveData()
+        filenames = next(os.walk(rawdir), (None, None, []))[2]
+        assert len(filenames) == 12
+    except Exception as e:
+        raise (e)
+    finally:
+        if os.path.exists(rawdir):
+            shutil.rmtree(rawdir, ignore_errors=True)
 
 
 if __name__ == "__main__":
-    fetcher_test()
+    os.environ["CALLED_FROM_PYTEST"] = "True"
+    skip_test_fetcher()


### PR DESCRIPTION
 - I tried to improve the help description for `textfile` (closes #929)
 - pytest-recording (https://github.com/kiwicom/pytest-recording) is a wrapper around vcrpy to help with tests. I tried this and I couldn't get it to work with obspy so we're still not testing downloads.
 - there was another bug in redirecting the obspy logger to the log file that I fixed. 
 - The solution to the multiple event problem is to copy the conf within the event loop when handing it off to the download function (closes #944); I still have a hard time recognizing when python just creates a pointer rather than copy.
 - This also improves support for events that are not in comcat.