### PR TITLE
Add waveqlab3d reader and corresponding test data.

### DIFF
--- a/gmprocess/io/waveqlab3d/core.py
+++ b/gmprocess/io/waveqlab3d/core.py
@@ -52,7 +52,7 @@ import numpy
 from gmprocess.surfacestream import SurfaceStream
 
 
-def is_waveqlab3d(filename):
+def is_waveqlab3d(filename, config=None):
     """Check to see if file is a waveqlab3d file.
 
     Args:


### PR DESCRIPTION
Still need to verify (1) ordering of values in fake data files matches
simulation output and (2) geometry and topology information matches
desired ordering.

I added the "congif=none" on the core.py file within waveqlab3d. This cleared up all the fails on my local.