### PR TITLE
Extend remove instrument response options

### DIFF
--- a/gmprocess/data/config_production.yml
+++ b/gmprocess/data/config_production.yml
@@ -232,6 +232,9 @@ processing:
     #     threshold: 3.0
 
     - remove_response:
+        #  Apply a bandpass filter in frequency domain to the data before deconvolution?
+        pre_filt: True
+
         # Pre-filtering frequencies. See obspy.core.trace.Trace.remove_response
         # for details. Note: if f3 is Null it will be set to 0.9*fn, if f4 is
         # Null it will be set to fn.
@@ -240,7 +243,7 @@ processing:
         f3: Null
         f4: Null
 
-        # Water level (dB) for deconvolution
+        # Water level (dB) for deconvolution; Set to Null to not apply a water level.
         water_level: 60.0
 
     - detrend:

--- a/gmprocess/data/config_test.yml
+++ b/gmprocess/data/config_test.yml
@@ -228,6 +228,7 @@ processing:
     #     threshold: 3.0
 
     - remove_response:
+        pre_filt: True
         # Pre-filtering frequencies. See obspy.core.trace.Trace.remove_response
         # for details. Note: if f3 is Null it will be set to 0.9*fn, if f4 is
         # Null it will be set to fn.

--- a/gmprocess/data/testdata/conf_small.yml
+++ b/gmprocess/data/testdata/conf_small.yml
@@ -173,6 +173,7 @@ processing:
         threshold: 3.0
 
     - remove_response:
+        pre_filt: True
         # Pre-filtering frequencies. See obspy.core.trace.Trace.remove_response
         # for details. Note: if f3 is Null it will be set to 0.9*fn, if f4 is
         # Null it will be set to fn.

--- a/gmprocess/data/testdata/config_min_freq_0p2.yml
+++ b/gmprocess/data/testdata/config_min_freq_0p2.yml
@@ -178,6 +178,7 @@ processing:
     #     threshold: 3.0
 
     - remove_response:
+        pre_filt: True
         # Pre-filtering frequencies. See obspy.core.trace.Trace.remove_response
         # for details. Note: if f3 is Null it will be set to 0.9*fn, if f4 is
         # Null it will be set to fn.

--- a/gmprocess/waveform_processing/processing.py
+++ b/gmprocess/waveform_processing/processing.py
@@ -235,7 +235,7 @@ def process_streams(streams, origin, config=None, old_streams=None):
 
 
 def remove_response(
-    st, f1, f2, f3=None, f4=None, water_level=None, inv=None, config=None
+    st, pre_filt, f1, f2, f3=None, f4=None, water_level=None, inv=None, config=None
 ):
     """
     Performs instrument response correction. If the response information is
@@ -249,6 +249,9 @@ def remove_response(
     Args:
         st (StationStream):
             Stream of data.
+        pre_filt (bool):
+            Apply a bandpass filter in frequency domain to the data before
+            deconvolution?
         f1 (float):
             Frequency 1 for pre-filter.
         f2 (float):
@@ -288,6 +291,10 @@ def remove_response(
             f3 = 0.9 * f_n
         if f4 is None:
             f4 = f_n
+        if pre_filt:
+            pre_filt_selected = (f1, f2, f3, f4)
+        else:
+            pre_filt_selected = None
         try:
             resp = inv.get_response(tr.id, tr.stats.starttime)
             paz = resp.get_paz()
@@ -302,7 +309,7 @@ def remove_response(
                         inventory=inv,
                         output="VEL",
                         water_level=water_level,
-                        pre_filt=(f1, f2, f3, f4),
+                        pre_filt=pre_filt_selected,
                         zero_mean=True,
                         taper=False,
                     )
@@ -313,7 +320,7 @@ def remove_response(
                             "input_units": "counts",
                             "output_units": ABBREV_UNITS["VEL"],
                             "water_level": water_level,
-                            "pre_filt_freqs": f"{f1:f}, {f2:f}, {f3:f}, {f4:f}",
+                            "pre_filt_freqs": str(pre_filt_selected),
                         },
                     )
                     diff_conf = config["differentiation"]
@@ -363,6 +370,7 @@ def remove_response(
                             inventory=inv,
                             output=output,
                             water_level=water_level,
+                            pre_filt=pre_filt_selected,
                             zero_mean=True,
                             taper=False,
                         )
@@ -374,7 +382,7 @@ def remove_response(
                                 "input_units": "counts",
                                 "output_units": ABBREV_UNITS[output],
                                 "water_level": water_level,
-                                "pre_filt_freqs": f"{f1:f}, {f2:f}, {f3:f}, {f4:f}",
+                                "pre_filt_freqs": str(pre_filt_selected),
                             },
                         )
                         tr.stats.standard.units = ABBREV_UNITS[output]

--- a/tests/gmprocess/io/obspy/obspy_test.py
+++ b/tests/gmprocess/io/obspy/obspy_test.py
@@ -6,7 +6,6 @@ from gmprocess.utils.test_utils import read_data_dir
 from gmprocess.core.streamcollection import StreamCollection
 from gmprocess.waveform_processing.processing import process_streams
 import numpy as np
-from numpy.testing import assert_almost_equal
 
 
 def test_sac_csn():
@@ -136,7 +135,7 @@ def test_weird_sensitivity():
     sc = StreamCollection(streams)
     psc = process_streams(sc, origin)
     channel = psc[0].select(component="E")[0]
-    assert_almost_equal(channel.data.max(), 62900.197618074293)
+    np.testing.assert_allclose(channel.data.max(), 62900.197618074293)
 
 
 def test():

--- a/tests/gmprocess/waveform_processing/lowpass_max_test.py
+++ b/tests/gmprocess/waveform_processing/lowpass_max_test.py
@@ -25,6 +25,7 @@ def test_lowpass_max():
             {"detrend": {"detrending_method": "demean"}},
             {
                 "remove_response": {
+                    "pre_filt": True,
                     "f1": 0.001,
                     "f2": 0.005,
                     "f3": None,


### PR DESCRIPTION
Add options to instrument response removal to allow for no water level and/or no pre filter. Closes #961. 

NOTE: This will require all users to update their config file in the instrument response section to add the new `pre_filt` key:
```yml
    - remove_response:
        #  Apply a bandpass filter in frequency domain to the data before deconvolution?
        pre_filt: True

        # Pre-filtering frequencies. See obspy.core.trace.Trace.remove_response
        # for details. Note: if f3 is Null it will be set to 0.9*fn, if f4 is
        # Null it will be set to fn.
        f1: 0.001
        f2: 0.005
        f3: Null
        f4: Null

        # Water level (dB) for deconvolution; Set to Null to not apply a water level.
        water_level: 60.0
```