### PR TITLE
Fixed missing loading config in report generation

### DIFF
--- a/gmprocess/subcommands/base.py
+++ b/gmprocess/subcommands/base.py
@@ -178,3 +178,10 @@ class SubcommandModule(ABC):
                 self.gmrecords.args.label = tmplab
         elif self.gmrecords.args.label is None:
             self.gmrecords.args.label = labels[0]
+
+    def _get_config(self):
+        if hasattr(self.workspace, "config"):
+            config = self.workspace.config
+        else:
+            config = confmod.get_config()
+        return config

--- a/gmprocess/subcommands/base.py
+++ b/gmprocess/subcommands/base.py
@@ -100,10 +100,7 @@ class SubcommandModule(ABC):
         if self.gmrecords.args.label is None:
             return
 
-        if hasattr(self.workspace, "config"):
-            config = self.workspace.config
-        else:
-            config = confmod.get_config()
+        config = self._get_config()
 
         self.pstreams = self.workspace.getStreams(
             self.eventid, labels=[self.gmrecords.args.label], config=config

--- a/gmprocess/subcommands/compute_station_metrics.py
+++ b/gmprocess/subcommands/compute_station_metrics.py
@@ -77,10 +77,7 @@ class ComputeStationMetricsModule(base.SubcommandModule):
         ds = self.workspace.dataset
         self._get_labels()
 
-        if hasattr(self.workspace, "config"):
-            config = self.workspace.config
-        else:
-            config = confmod.get_config()
+        config = self._get_config()
 
         if not hasattr(self, "vs30_grids"):
             vs30_grids = None

--- a/gmprocess/subcommands/compute_waveform_metrics.py
+++ b/gmprocess/subcommands/compute_waveform_metrics.py
@@ -67,10 +67,7 @@ class ComputeWaveformMetricsModule(base.SubcommandModule):
         ds = self.workspace.dataset
         station_list = ds.waveforms.list()
         self._get_labels()
-        if hasattr(self.workspace, "config"):
-            config = self.workspace.config
-        else:
-            config = confmod.get_config()
+        config = self._get_config()
 
         summaries = []
         metricpaths = []

--- a/gmprocess/subcommands/export_metric_tables.py
+++ b/gmprocess/subcommands/export_metric_tables.py
@@ -56,10 +56,7 @@ class ExportMetricTablesModule(base.SubcommandModule):
 
             self.workspace = ws.StreamWorkspace.open(workname)
             self._get_labels()
-            if hasattr(self.workspace, "config"):
-                config = self.workspace.config
-            else:
-                config = confmod.get_config()
+            config = self._get_config()
 
             event_table, imc_tables, readmes = self.workspace.getTables(
                 self.gmrecords.args.label, config

--- a/gmprocess/subcommands/export_shakemap.py
+++ b/gmprocess/subcommands/export_shakemap.py
@@ -66,10 +66,7 @@ class ExportShakeMapModule(base.SubcommandModule):
 
             self.workspace = ws.StreamWorkspace.open(workname)
             self._get_labels()
-            if hasattr(self.workspace, "config"):
-                config = self.workspace.config
-            else:
-                config = confmod.get_config()
+            config = self._get_config()
 
             expanded_imts = self.gmrecords.args.expand_imts
             jsonfile, stationfile, _ = sm_utils.create_json(

--- a/gmprocess/subcommands/generate_report.py
+++ b/gmprocess/subcommands/generate_report.py
@@ -55,7 +55,7 @@ class GenerateReportModule(base.SubcommandModule):
 
             logging.info(f"Generating summary report for event {event.id}...")
 
-            config = self.workspace.config
+            config = self._get_config()
             build_conf = config["build_report"]
             report_format = build_conf["format"]
             if report_format == "latex":
@@ -87,7 +87,7 @@ class GenerateReportModule(base.SubcommandModule):
             return False
 
         self.workspace = ws.StreamWorkspace.open(workname)
-        config = self.workspace.config
+        config = self._get_config()
         ds = self.workspace.dataset
         station_list = ds.waveforms.list()
         if len(station_list) == 0:

--- a/gmprocess/subcommands/process_waveforms.py
+++ b/gmprocess/subcommands/process_waveforms.py
@@ -93,10 +93,7 @@ class ProcessWaveformsModule(base.SubcommandModule):
 
         for station_id in station_list:
             # Cannot parallelize IO to ASDF file
-            if hasattr(workspace, "config"):
-                config = workspace.config
-            else:
-                config = confmod.get_config()
+            config = self._get_config()
             raw_streams = workspace.getStreams(
                 event.id,
                 stations=[station_id],


### PR DESCRIPTION
The gmrecords subcommands all used various forms of:
```python
if hasattr(self.workspace, "config"):
    config = self.workspace.config
else:
    config = confmod.get_config()
```
This was add to the base subcommand as `_load_config()` and replaced the code in the children subcommands. This change simplifies things and makes loading the config more maintainable.