### PR TITLE
Fix tests to use explicit hann window with obspy.

### DIFF
--- a/gmprocess/waveform_processing/phase.py
+++ b/gmprocess/waveform_processing/phase.py
@@ -192,7 +192,7 @@ def PowerPicker(
             P-wave pick time as number of seconds after start of trace.
     """
     tr_copy = tr.copy()
-    tr_copy.resample(20)
+    tr_copy.resample(20, window='hann')
     tr_copy.detrend()
     data = tr_copy.data
     sps = tr_copy.stats.sampling_rate

--- a/tests/gmprocess/core/streamcollection_test.py
+++ b/tests/gmprocess/core/streamcollection_test.py
@@ -200,13 +200,13 @@ def test_duplicates():
 
     for tr in sc_bad.select(network="--")[0]:
         tr.trim(endtime=UTCDateTime(2))
-        tr.resample(20)
+        tr.resample(20, window='hann')
 
     sc = StreamCollection(streams=sc_bad.streams, handle_duplicates=True)
     assert sc.select(station="23837")[0][0].stats.network == "CE"
 
     for tr in sc_bad.select(network="--")[0]:
-        tr.resample(10)
+        tr.resample(10, window='hann')
 
     sc = StreamCollection(streams=sc_bad.streams, handle_duplicates=True)
     assert sc.select(station="23837")[0][0].stats.network == "CE"


### PR DESCRIPTION
scipy is now using *hann*, instead of *hanning*, for the window name. Specify this window explicitly.