### PR TITLE
Add config subcommand

### DIFF
--- a/doc_source/contents/developer/changelog.md
+++ b/doc_source/contents/developer/changelog.md
@@ -6,6 +6,8 @@
 - Data fetcher bugfix.
 - Improvement to Windows install instructions.
 - Add changelog.
+- Add "config" subcommand to gmrecords.
+- Fix pandas to_latex warning.
 
 ## 1.2.0 / 2022-08-15
 

--- a/src/gmprocess/apps/gmrecords.py
+++ b/src/gmprocess/apps/gmrecords.py
@@ -347,9 +347,17 @@ class GMrecordsApp(object):
         parsers = []
         for cname, cdict in self.classes.items():
             command_description = inspect.getdoc(cdict["class"])
+            if hasattr(cdict["class"], "epilog"):
+                epilog = cdict["class"].epilog
+            else:
+                epilog = None
             parsers.append(
                 subparsers.add_parser(
-                    cname, help=command_description, aliases=cdict["class"].aliases
+                    cname,
+                    help=command_description,
+                    aliases=cdict["class"].aliases,
+                    epilog=epilog,
+                    formatter_class=argparse.RawDescriptionHelpFormatter,
                 )
             )
             arg_list = cdict["class"].arguments

--- a/src/gmprocess/io/asdf/stream_workspace.py
+++ b/src/gmprocess/io/asdf/stream_workspace.py
@@ -385,14 +385,15 @@ class StreamWorkspace(object):
             if overwrite:
                 net_sta = stream.get_net_sta()
                 if net_sta in self.dataset.waveforms:
-                    tmp_stream = self.dataset.waveforms[net_sta][tag]
-                    tmp_stats = tmp_stream[0].stats
-                    tmp_nsl = ".".join(
-                        [tmp_stats.network, tmp_stats.station, tmp_stats.location]
-                    )
-                    nsl = stream.get_net_sta_loc()
-                    if nsl == tmp_nsl:
-                        del self.dataset.waveforms[net_sta][tag]
+                    if tag in self.dataset.waveforms[net_sta]:
+                        tmp_stream = self.dataset.waveforms[net_sta][tag]
+                        tmp_stats = tmp_stream[0].stats
+                        tmp_nsl = ".".join(
+                            [tmp_stats.network, tmp_stats.station, tmp_stats.location]
+                        )
+                        nsl = stream.get_net_sta_loc()
+                        if nsl == tmp_nsl:
+                            del self.dataset.waveforms[net_sta][tag]
 
             self.dataset.add_waveforms(stream, tag=tag, event_id=event)
 
@@ -1336,14 +1337,10 @@ class StreamWorkspace(object):
             row["Software"] = software["name"]
             row["Version"] = software["version"]
             df = df.append(row, ignore_index=True)
-        breakpoint()
         return df
 
-    def getInventory(self, eventid):
+    def getInventory(self):
         """Get an Obspy Inventory object from the ASDF file.
-
-        Args:
-            eventid (str): ID of event to search for in ASDF file.
 
         Returns:
             Inventory: Obspy inventory object capturing all of the

--- a/src/gmprocess/io/obspy/fdsn_fetcher.py
+++ b/src/gmprocess/io/obspy/fdsn_fetcher.py
@@ -184,6 +184,8 @@ class FDSNFetcher(DataFetcher):
 
         client_list = []
         for provider_str in providers.keys():
+            if provider_str == "NCEDC":
+                continue
             if provider_str == GEO_NET_ARCHIVE_KEY:
                 dt = UTCDateTime.utcnow() - UTCDateTime(self.time)
                 if dt < GEONET_ARCHIVE_DAYS:

--- a/src/gmprocess/io/report.py
+++ b/src/gmprocess/io/report.py
@@ -5,6 +5,7 @@
 import os
 from shutil import which
 import glob
+import re
 
 # third party imports
 import numpy as np
@@ -313,7 +314,14 @@ def get_prov_latex(st):
         last_row = row
 
     newdf = pd.DataFrame(final_dict)
-    prov_string = newdf.to_latex(index=False)
+    # prov_string = newdf.to_latex(index=False)
+    newdf = newdf.applymap(str_for_latex)
+    prov_string = newdf.style.to_latex(hrules=True)
+    # Annoying hack because pandas removed the functionality to hide the index when
+    # writing to latex.
+    prov_string = prov_string.replace("{llll", "{lll")
+    prov_string = re.sub(r"\n\d* &", "\n", prov_string)
+
     prov_string = "\\tiny\n" + prov_string
     return prov_string
 

--- a/src/gmprocess/subcommands/base.py
+++ b/src/gmprocess/subcommands/base.py
@@ -5,6 +5,7 @@ import os
 import sys
 from abc import ABC, abstractmethod
 import logging
+from pathlib import Path
 
 from gmprocess.subcommands.lazy_loader import LazyLoader
 
@@ -35,17 +36,17 @@ class SubcommandModule(ABC):
 
     def open_workspace(self, eventid):
         """Open workspace, add as attribute."""
-        event_dir = os.path.join(self.gmrecords.data_path, eventid)
-        workname = os.path.join(event_dir, const.WORKSPACE_NAME)
-        if not os.path.isfile(workname):
+        event_dir = Path(self.gmrecords.data_path) / eventid
+        workname = event_dir / const.WORKSPACE_NAME
+        if not workname.exists():
             logging.info(
                 "No workspace file found for event %s. Please run "
                 "subcommand 'assemble' to generate workspace file."
             )
             logging.info("Continuing to next event.")
-            return eventid
-
-        self.workspace = ws.StreamWorkspace.open(workname)
+            self.workspace = None
+        else:
+            self.workspace = ws.StreamWorkspace.open(workname)
 
     def close_workspace(self):
         """Close workspace."""

--- a/src/gmprocess/subcommands/config.py
+++ b/src/gmprocess/subcommands/config.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import logging
+from pathlib import Path
+
+from gmprocess.subcommands.lazy_loader import LazyLoader
+from gmprocess.subcommands.arg_dicts import ARG_DICTS
+
+base = LazyLoader("base", globals(), "gmprocess.subcommands.base")
+const = LazyLoader("const", globals(), "gmprocess.utils.constants")
+ws = LazyLoader("ws", globals(), "gmprocess.io.asdf.stream_workspace")
+confmod = LazyLoader("confmod", globals(), "gmprocess.utils.config")
+ryaml = LazyLoader("yaml", globals(), "ruamel.yaml")
+
+
+class ConfigModule(base.SubcommandModule):
+    """Utilities to deal with config option issues."""
+
+    epilog = """
+    Config options are specified in the yml files in the config directory for each
+    project. These are read in and stored in a config object in the workspace file
+    for each event when the workspace file is created by the `assemble` subcommand.
+
+    It sometimes occurs that the config file structure needs to be updated in a way
+    that is not backwards compatible. The priory purpose of this subcommand is to
+    help users resolve this problem.
+
+    Updating the config options in the workspace file can cause an inconsistency in
+    that the config options will no longer match previously processed data in that
+    workspace file. Thus, the provenance information should be used as the authoritative
+    source for documenting the options that were used.
+
+    Another concern is that any customization of the config options could be lost in the
+    update. So it is very important that the user be sure that the project config
+    options include any customizations before updating the config in the workspace
+    files.
+
+    The `save` option is included for this subcommand as a quick way to export the
+    contents of the config options with the idea that this could be compared to the
+    current project config file to look for any customizatized options.
+    """
+    command_name = "config"
+
+    arguments = [
+        {
+            "short_flag": "-u",
+            "long_flag": "--update",
+            "help": (
+                "Replace the config in the workspace files with the config."
+                "in the current project."
+            ),
+            "default": False,
+            "action": "store_true",
+        },
+        {
+            "short_flag": "-s",
+            "long_flag": "--save",
+            "help": "Save the contents of the workspace config to a file.",
+            "type": str,
+            "default": None,
+            "metavar": "filename",
+        },
+        ARG_DICTS["eventid"],
+    ]
+
+    def main(self, gmrecords):
+        """
+        Help with the config.
+
+        Args:
+            gmrecords:
+                GMrecordsApp instance.
+        """
+        logging.info(f"Running subcommand '{self.command_name}'")
+        self.gmrecords = gmrecords
+        self._check_arguments()
+        self._get_events()
+
+        logging.info(f"Number of events: {len(self.events)}")
+
+        # Grab the config from the project on the file system
+        proj_config = confmod.get_config(gmrecords.conf_path)
+
+        for event in self.events:
+            event_dir = Path(self.gmrecords.data_path) / event.id
+            if event_dir.exists():
+                workname = event_dir / const.WORKSPACE_NAME
+
+                if not workname.exists():
+                    logging.info(f"No workspace file found for event {event.id}")
+                    logging.info("Continuing to next event.")
+                    continue
+
+                # Open workspace file
+                workspace = ws.StreamWorkspace.open(workname)
+
+                # Save the workspace configs to file?
+                if self.gmrecords.args.save is not None:
+                    group_name = "config/config"
+                    config_exists = (
+                        group_name in workspace.dataset._auxiliary_data_group
+                    )
+                    if config_exists:
+                        logging.info(f"Saving config for {event.id}.")
+                        fname = self.gmrecords.args.save
+                        yaml = ryaml.YAML()
+                        yaml.indent(mapping=4)
+                        yaml.preserve_quotes = True
+                        with open(fname, "a", encoding="utf-8") as yf:
+                            yf.write(f"# Path: {str(workname)}\n")
+                            yaml.dump(workspace.config, yf)
+                    else:
+                        logging.info(f"No config in workspace for event {event.id}.")
+                if self.gmrecords.args.update:
+                    # Write project config to workspace
+                    logging.info(f"Adding config {event.id} workspace file.")
+                    workspace.addConfig(config=proj_config, force=True)

--- a/src/gmprocess/subcommands/export_failure_tables.py
+++ b/src/gmprocess/subcommands/export_failure_tables.py
@@ -63,8 +63,8 @@ class ExportFailureTablesModule(base.SubcommandModule):
             workname = os.path.normpath(os.path.join(event_dir, const.WORKSPACE_NAME))
             if not os.path.isfile(workname):
                 logging.info(
-                    "No workspace file found for event %s. Please run "
-                    "subcommand 'assemble' to generate workspace file." % self.eventid
+                    f"No workspace file found for event {self.eventid}. Please run "
+                    "subcommand 'assemble' to generate workspace file."
                 )
                 logging.info("Continuing to next event.")
                 continue

--- a/src/gmprocess/subcommands/process_waveforms.py
+++ b/src/gmprocess/subcommands/process_waveforms.py
@@ -46,6 +46,7 @@ class ProcessWaveformsModule(base.SubcommandModule):
             "action": "store_true",
         },
         arg_dicts.ARG_DICTS["num_processes"],
+        arg_dicts.ARG_DICTS["overwrite"],
     ]
 
     def main(self, gmrecords):
@@ -72,6 +73,8 @@ class ProcessWaveformsModule(base.SubcommandModule):
 
     def _process_event(self, event):
         self.open_workspace(event.id)
+        if self.workspace is None:
+            return
         ds = self.workspace.dataset
         station_list = ds.waveforms.list()
 
@@ -136,11 +139,11 @@ class ProcessWaveformsModule(base.SubcommandModule):
             # Collect the processed streams
             processed_streams = [future.result() for future in futures]
 
-        # Cannot parallelize IO to ASDF file
+        # Note: cannot parallelize IO to ASDF file
+
+        overwrite = self.gmrecords.args.overwrite
         if self.gmrecords.args.reprocess:
             overwrite = True
-        else:
-            overwrite = False
 
         for processed_stream in processed_streams:
             self.workspace.addStreams(

--- a/src/gmprocess/utils/assemble_utils.py
+++ b/src/gmprocess/utils/assemble_utils.py
@@ -71,7 +71,6 @@ def assemble(event, config, directory, gmprocess_version):
     else:
         stream_array = StreamArray(streams)
 
-    logging.info("stream_array.describe_string():")
     logging.info(stream_array.describe_string())
 
     # Create the workspace file and put the unprocessed waveforms in it

--- a/src/gmprocess/utils/config.py
+++ b/src/gmprocess/utils/config.py
@@ -271,8 +271,8 @@ def get_config(config_path=None):
 
     # Read in default config from the repository
     data_dir = Path(__file__).parent / ".." / "data"
-    default_config_file = os.path.join(data_dir, constants.CONFIG_FILE_PRODUCTION)
-    if not os.path.isfile(default_config_file):
+    default_config_file = data_dir / constants.CONFIG_FILE_PRODUCTION
+    if not default_config_file.exists():
         fmt = "Missing config file: %s."
         raise OSError(fmt % default_config_file)
     else:


### PR DESCRIPTION
Added the "config" subcommand that has options to save the config in the workspace files to a file for review, and also to update the config in the workspace file with the config options that are currently specified in the projects's conf directory. This is intended to help users that have older workspace files that have config options in them that are no longer compatible with the current version of the code. Be careful when running the update, though, to be sure that any customizations are reflected by the project's config file. 