### PR TITLE
Remove redundant retrieval of event information from ComCat.

### DIFF
--- a/src/gmprocess/subcommands/assemble.py
+++ b/src/gmprocess/subcommands/assemble.py
@@ -43,7 +43,6 @@ class AssembleModule(base.SubcommandModule):
 
         logging.info(f"Number of events to assemble: {len(self.events)}")
 
-        events = [e.id for e in self.events]
         data_path = self.gmrecords.data_path
         overwrite = self.gmrecords.args.overwrite
         conf = self.gmrecords.conf
@@ -55,9 +54,9 @@ class AssembleModule(base.SubcommandModule):
             executor = ProcessPoolExecutor(
                 max_workers=self.gmrecords.args.num_processes
             )
-            for ievent, event in enumerate(events):
+            for ievent, event in enumerate(self.events):
                 logging.info(
-                    f"Assembling event {event} ({1+ievent} of {len(events)})..."
+                    f"Assembling event {event.id} ({1+ievent} of {len(self.events)})..."
                 )
                 future = executor.submit(
                     self._assemble_event,
@@ -71,9 +70,9 @@ class AssembleModule(base.SubcommandModule):
             results = [future.result() for future in futures]
             executor.shutdown()
         else:
-            for ievent, event in enumerate(events):
+            for ievent, event in enumerate(self.events):
                 logging.info(
-                    f"Assembling event {event} ({1+ievent} of {len(events)})..."
+                    f"Assembling event {event.id} ({1+ievent} of {len(self.events)})..."
                 )
                 results.append(
                     self._assemble_event(event, data_path, overwrite, conf, version)
@@ -89,7 +88,7 @@ class AssembleModule(base.SubcommandModule):
     # call it with ProcessPoolExecutor.
     @staticmethod
     def _assemble_event(event, data_path, overwrite, conf, version):
-        event_dir = os.path.normpath(os.path.join(data_path, event))
+        event_dir = os.path.normpath(os.path.join(data_path, event.id))
         if not os.path.exists(event_dir):
             os.makedirs(event_dir)
         workname = os.path.normpath(os.path.join(event_dir, constants.WORKSPACE_NAME))

--- a/src/gmprocess/utils/assemble_utils.py
+++ b/src/gmprocess/utils/assemble_utils.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from gmprocess.core.streamcollection import StreamCollection
 from gmprocess.core.streamarray import StreamArray
 from gmprocess.utils.constants import WORKSPACE_NAME
-from gmprocess.utils.event import get_event_object
 from gmprocess.io.asdf.stream_workspace import StreamWorkspace
 from gmprocess.io.read_directory import directory_to_streams
 from gmprocess.utils.misc import get_rawdir
@@ -82,14 +81,13 @@ def assemble(event, config, directory, gmprocess_version):
         os.remove(workname)
 
     workspace = StreamWorkspace(workname)
-    event_obj = get_event_object(event)
-    workspace.addEvent(event_obj)
+    workspace.addEvent(event)
     logging.debug("workspace.dataset.events:")
     logging.debug(workspace.dataset.events)
     workspace.addGmprocessVersion(gmprocess_version)
     workspace.addConfig(config=config)
     workspace.addStreams(
-        event_obj,
+        event,
         stream_array,
         label="unprocessed",
         gmprocess_version=gmprocess_version,

--- a/src/gmprocess/utils/assemble_utils.py
+++ b/src/gmprocess/utils/assemble_utils.py
@@ -46,16 +46,16 @@ def assemble(event, config, directory, gmprocess_version):
             - str: Path to the rupture file.
     """
 
-    # Make raw directory
-    in_event_dir = os.path.join(directory, event)
-    in_raw_dir = get_rawdir(in_event_dir)
-    logging.debug(f"in_raw_dir: {in_raw_dir}")
+    # Get raw directory
+    event_dir = directory / event.id
+    raw_dir = get_rawdir(event_dir)
+    logging.debug(f"raw_dir: {raw_dir}")
     streams, unprocessed_files, unprocessed_file_errors = directory_to_streams(
-        in_raw_dir, config=config
+        raw_dir, config=config
     )
     # Write errors to a csv file (but not for tests)
     if os.getenv("CALLED_FROM_PYTEST") is None:
-        failures_file = Path(in_raw_dir) / "read_failures.csv"
+        failures_file = Path(raw_dir) / "read_failures.csv"
         colnames = ["File", "Failure"]
         with open(failures_file, "w", newline="") as f:
             writer = csv.writer(f, delimiter=",", quoting=csv.QUOTE_MINIMAL)
@@ -74,11 +74,9 @@ def assemble(event, config, directory, gmprocess_version):
     logging.info(stream_array.describe_string())
 
     # Create the workspace file and put the unprocessed waveforms in it
-    workname = os.path.join(in_event_dir, WORKSPACE_NAME)
-
-    # Remove any existing workspace file
-    if os.path.isfile(workname):
-        os.remove(workname)
+    workname = event_dir / WORKSPACE_NAME
+    if workname.is_file():
+        workname.unlink()
 
     workspace = StreamWorkspace(workname)
     workspace.addEvent(event)

--- a/src/gmprocess/utils/base_utils.py
+++ b/src/gmprocess/utils/base_utils.py
@@ -119,11 +119,8 @@ def get_event_files(directory):
         List of event.json files.
     """
     eventfiles = []
-    for root, dirs, files in os.walk(directory):
-        for name in files:
-            if name == "event.json":
-                fullname = os.path.join(root, name)
-                eventfiles.append(fullname)
+    for filename in directory.glob("**/event.json"):
+        eventfiles.append(filename)
     return eventfiles
 
 

--- a/src/gmprocess/utils/misc.py
+++ b/src/gmprocess/utils/misc.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
-
 
 def get_rawdir(event_dir):
     """Find or create raw directory if necessary.
@@ -11,7 +9,6 @@ def get_rawdir(event_dir):
         event_dir (str):
             Directory where raw directory will be found or created.
     """
-    rawdir = os.path.join(event_dir, "raw")
-    if not os.path.exists(rawdir):
-        os.makedirs(rawdir)
+    rawdir = event_dir / "raw"
+    rawdir.mkdir(exist_ok=True)
     return rawdir


### PR DESCRIPTION
* Remove redundant retrieval of event information from ComCat in the gmrecords assemble subcommand.
* Migrate some use of `os.path` to `pathlib` methods.

Closes #1030 