### PR TITLE
Bugfix on config path

### DIFF
--- a/src/gmprocess/apps/gmrecords.py
+++ b/src/gmprocess/apps/gmrecords.py
@@ -196,17 +196,16 @@ class GMrecordsApp(object):
             str(self.projects_file), encoding="utf-8"
         )
         projmod.validate_projects_config(self.projects_conf, self.projects_path)
-        current_project = projmod.get_current(self.projects_conf)
 
         if "CALLED_FROM_PYTEST" in os.environ:
-            conf_path = const.CONFIG_PATH_TEST  # ~/gmptest
+            conf_path = const.CONFIG_PATH_TEST
             conf_path.mkdir(exist_ok=True)
             test_conf_file = (const.DATA_DIR / const.CONFIG_FILE_TEST).resolve()
             shutil.copyfile(test_conf_file, conf_path / const.CONFIG_FILE_TEST)
 
         subcommands_need_conf = ["download", "assemble", "auto_shakemap"]
         if self.args.func.command_name in subcommands_need_conf:
-            self.conf = configmod.get_config(config_path=self.projects_path)
+            self.conf = configmod.get_config(config_path=self.conf_path)
 
     def _initial_setup(self):
         """

--- a/src/gmprocess/subcommands/assemble.py
+++ b/src/gmprocess/subcommands/assemble.py
@@ -79,8 +79,8 @@ class AssembleModule(base.SubcommandModule):
                 )
 
         for res in results:
-            print(res)
-            self.append_file("Workspace", res)
+            if res is not None:
+                self.append_file("Workspace", res)
 
         self._summarize_files_created()
 
@@ -97,8 +97,8 @@ class AssembleModule(base.SubcommandModule):
             logging.info(f"ASDF exists: {workname}")
             if not overwrite:
                 logging.info("The --overwrite argument not selected.")
-                logging.info(f"No action taken for {event}.")
-                return event
+                logging.info(f"No action taken for {event.id}.")
+                return None
             else:
                 logging.info(f"Removing existing ASDF file: {workname}")
                 os.remove(workname)


### PR DESCRIPTION
- The projects path was being handed off to `get_config` in `GMrecordsApp` which meant that none of the project-specific configs were being found and so they were not getting used. 
- When assemble fails, the `_assemble_event` method returns the event object rather than the workspace file name, which caused an error when `_summarize_files_created` is called, rather than exiting gracefully. 