### PR TITLE
Fixed sac units conversion issue

### DIFF
--- a/doc_source/contents/developer/changelog.md
+++ b/doc_source/contents/developer/changelog.md
@@ -7,6 +7,7 @@
   - Always prompt for names of 'data' and 'conf' directories with reasonable defaults.
   - Provide appropriate error message when attempting to list, switch, or delete projects when none exist.
   - Allow use of projects subcommand from Python scripts.
+- Fixes SAC format units conversion issue. 
 
 ## 1.2.1 / 2022-10-04
 

--- a/src/gmprocess/core/stationtrace.py
+++ b/src/gmprocess/core/stationtrace.py
@@ -250,13 +250,6 @@ class StationTrace(Trace):
             if delta < MAX_DIP_OFFSET and not is_z:
                 header["channel"] = header["channel"][0:-1] + "Z"
 
-        # Apply conversion factor if one was specified for this format
-        if (
-            "format_specific" in header
-            and "conversion_factor" in header["format_specific"]
-        ):
-            data *= header["format_specific"]["conversion_factor"]
-
         super(StationTrace, self).__init__(data=data, header=header)
         self.provenance = []
         if prov_response is not None:
@@ -1054,9 +1047,6 @@ def _stats_from_inventory(data, inventory, seed_id, start_time):
     else:
         standard["vertical_orientation"] = np.nan
 
-    # if "units_type" not in standard.keys() or standard["units_type"] == "":
-    #     standard["units_type"] = get_units_type(channel_code)
-    # print(f"Stationtrace.py line 761: {standard['units_type']}")
     if len(channel.comments):
         comments = " ".join(
             channel.comments[i].value for i in range(len(channel.comments))
@@ -1146,7 +1136,6 @@ def _stats_from_header(header, config):
             utype = get_units_type(header["channel"])
             standard["units_type"] = utype
             standard["units"] = UNITS[utype]
-        print(f"Stationtrace.py line 844: {standard['units_type']}")
         standard["comments"] = ""
         standard["station_name"] = ""
         standard["station_name"] = header["station"]

--- a/src/gmprocess/io/obspy/core.py
+++ b/src/gmprocess/io/obspy/core.py
@@ -2,7 +2,6 @@
 
 # stdlib imports
 import os
-import sys
 import logging
 import glob
 import re
@@ -127,8 +126,6 @@ def is_obspy(filename, config=None):
     except BaseException:
         return False
 
-    return False
-
 
 def read_obspy(filename, config=None, **kwargs):
     """Read Obspy data file (SAC and MiniSEED currently supported).
@@ -214,7 +211,8 @@ def read_obspy(filename, config=None, **kwargs):
                 continue
             else:
                 logging.info(
-                    f"Ignoring {instrument} because it matches exclude pattern {pattern}."
+                    f"Ignoring {instrument} because it matches exclude "
+                    f"pattern {pattern}."
                 )
                 break
 
@@ -228,6 +226,11 @@ def read_obspy(filename, config=None, **kwargs):
                     trace.stats.standard.structure_type = sdict["description"]
         head, tail = os.path.split(filename)
         trace.stats["standard"]["source_file"] = tail or os.path.basename(head)
+
+        # Do SAC-specific stuff
+        if "_format" in trace.stats and trace.stats._format.lower() == "sac":
+            # Apply conversion factor if one was specified for this format
+            trace.data *= float(config["read"]["sac_conversion_factor"])
 
         traces.append(trace)
     if no_match:


### PR DESCRIPTION
Closes #992
- Moves the application of the conversion to the `read_obspy` module; this was in the `StationTrace` init method and was the reason for the bug since it is called both when the data is read in and then also when the data is retrieved from the HDF file. 
- Added a unit test for CSN SAC data; confirmed that the resulting values give similar results to a nearby permanent station. 