### PR TITLE
Switch stream failure detection/plotting , allow for plotting stations as passe…

### DIFF
--- a/src/gmprocess/utils/report_utils.py
+++ b/src/gmprocess/utils/report_utils.py
@@ -31,9 +31,8 @@ def draw_stations_map(pstreams, event, event_dir):
     )
     chans = [[tr.stats.channel for tr in st] for st in pstreams]
 
-    failed_st = np.array(
-        [np.any([tr.hasParameter("failure") for tr in st]) for st in pstreams]
-    )
+    failed_st = np.array([not st.passed for st in pstreams])
+
     failed_tr = np.array(
         [[tr.hasParameter("failure") for tr in st] for st in pstreams], dtype="object"
     )[failed_st]


### PR DESCRIPTION
Switch stream failure detection/plotting , allow for plotting stations with failed traces as `passed` with new check_stream config option

This is a minor fix that closes #1050 

A separate PR to improve the popup information provided for passed stations with failed traces will follow, relevant to the feature request #1052 