### PR TITLE
Fix Ridder loop to work when any_trace_failures is False

### DIFF
--- a/src/gmprocess/waveform_processing/adjust_highpass_ridder.py
+++ b/src/gmprocess/waveform_processing/adjust_highpass_ridder.py
@@ -60,6 +60,8 @@ def ridder_fchp(st, target=0.02, tol=0.001, maxiter=30, maxfc=0.5, config=None):
         filter_code = 0
 
     for tr in st:
+        if not tr.passed:
+            continue
         initial_corners = tr.getParameter("corner_frequencies")
         if initial_corners["type"] == "reviewed":
             continue

--- a/src/gmprocess/waveform_processing/corner_frequencies.py
+++ b/src/gmprocess/waveform_processing/corner_frequencies.py
@@ -61,6 +61,7 @@ def get_corner_frequencies(
         st = from_magnitude(st, origin, **magnitude)
     elif method == "snr":
         st = from_snr(st, **snr)
+        # Constrain the two horizontals to have the same corner frequencies?
         if snr["same_horiz"] and st.passed and st.num_horizontal > 1:
             hlps = [
                 tr.getParameter("corner_frequencies")["lowpass"]
@@ -124,8 +125,6 @@ def lowpass_max_frequency(st, fn_fac=0.75, lp_max=40.0, config=None):
     Returns:
         StationStream: Resampled stream.
     """
-    if not st.passed:
-        return st
 
     def _cap_lowpass(fc):
         freq_dict = tr.getParameter("corner_frequencies")


### PR DESCRIPTION
This fixes a bug that can come up when an individual trace has failed qa checks and so it didn't find corner frequencies. We just need to always check that individual traces have passed before looking for attributes like this. 